### PR TITLE
feat: blog editorial skills (five skills + deterministic integrity fixer)

### DIFF
--- a/.claude/skills/_shared/definition-of-done.md
+++ b/.claude/skills/_shared/definition-of-done.md
@@ -1,0 +1,27 @@
+# Definition of Done (quality gates)
+
+Single source of truth for the publish gates. `verify-post` runs every gate below; the five blog
+skills link here by name instead of repeating the list. A candidate may open a PR only if every gate
+passes. These encode the exact failures hit during the manual dry run.
+
+Completeness set for this phase is exactly `pl, en, de, fr`. The i18n code also lists `es`, but no
+posts are translated to it yet, so Phase 1 does not require `es`.
+
+Only DoD-4 (canonical slugs) and DoD-5 (tags) are deterministically auto fixed, by
+`src/lib/post-integrity.ts` via `bun run fix:post-integrity --slug <slug> --lang <lang>`. Every other
+gate is a hard fail: fix the source, do not paper over it.
+
+| Gate | Check | Auto fix |
+|---|---|---|
+| DoD-1 Voice | `pl.mdx` reads as the author, not as AI. First person, struggle journey, ironic ending, real specifics, zero em dashes (checked mechanically), no "let's dive in" AI tells. | no, hard fail (em dash is a hard fail if present after the draft stage) |
+| DoD-2 Completeness | `pl`, `en`, `de`, `fr` all exist. | no, hard fail |
+| DoD-3 No truncation | Each translation is at least 70 percent of the Polish word count and ends on a complete section. Translations run 100 to 135 percent in practice; below 70 percent means the model was cut off. | no, hard fail |
+| DoD-4 Canonical slugs | Every real internal Markdown link `](/blog/<lang>/<slug>)` uses a slug that is an existing content directory. The language segment may be localized; the slug may not. | yes, rewrite any non canonical slug back to the canonical directory name (see failure mode F3) |
+| DoD-5 Tags | `tags` line present and identical across all four languages. The translator drops them by default. | yes, re insert the canonical tags line if missing (see failure mode F4) |
+| DoD-6 OG | `coverImage` is absent (so the dynamic OG is used) or points to a real file. The post's `og:image` URL renders HTTP 200 and resolves to the correct topic theme. Run this per language, not just once against `pl`, since tag drift in one translation can silently mis resolve just that language's OG theme. | no, hard fail |
+| DoD-7 Renders | Every one of the four pages returns HTTP 200 from an in session build (`bun run build`, then a local server and curl). | no, hard fail |
+| DoD-8 Frontmatter | `description` at most 160 chars, valid `date`, tags well formed. | no, hard fail |
+| DoD-9 Post deploy | After the eventual merge to `prod`, `sitemap.xml` contains the new post with `hreflang` for all languages. Phase D deferred: `verify-post` does not run this gate in Phase 1. | no, hard fail (deferred to Phase D) |
+
+Slug and tag checks are mandatory and deterministic, not advisory. Prompts do not reliably prevent
+the slug and tag failures; the post check is the real guard. See `failure-modes.md` for F3 and F4.

--- a/.claude/skills/_shared/failure-modes.md
+++ b/.claude/skills/_shared/failure-modes.md
@@ -1,0 +1,65 @@
+# Known failure modes and required mitigations
+
+Learned the hard way during the manual dry run. The system must handle all of them. The five blog
+skills link here by name instead of repeating the list. F3 and F4 are closed by deterministic code:
+`src/lib/post-integrity.ts`, invoked via `bun run fix:post-integrity --slug <slug> --lang <lang>`.
+
+## F1. Groq daily token cap (TPD 100000 per day)
+
+Long posts consume roughly 11k tokens each; a full batch can exhaust the daily budget and then every
+translation fails with a `tokens per day` error.
+
+Mitigation: detect the TPD error explicitly; when hit, fall back to translating the remaining files
+with the running agent's own model (still enforcing DoD-4 and DoD-5) rather than blocking for an hour.
+Report which languages were produced by which path.
+
+## F2. Groq per minute cap (TPM 12000 per minute)
+
+A single request of prompt plus output must stay under 12000, and back to back requests in one minute
+exceed it.
+
+Mitigation: the output cap is already 6000; space requests about 65 seconds apart; retry with backoff.
+
+## F3. Slug translation bug
+
+The model translates the human readable words inside URL slugs (for example `/blog/de/proxmox-czesc-druga`
+became `/blog/de/proxmox-teil-zwei`), producing 404s, because a slug looks like translatable prose but
+is actually a shared identifier.
+
+Mitigation: the prompt now forbids it, but prompts are not reliable for this, so a deterministic post
+check rewrites any non canonical slug back to the canonical directory name. Implemented in
+`src/lib/post-integrity.ts` (`rewriteInternalSlugLinks`), run via `bun run fix:post-integrity`. This
+check is mandatory (DoD-4), not advisory.
+
+## F4. Dropped tags
+
+The translator's prompt historically listed only `title, description, date` as keys to preserve, so
+the model silently dropped the `tags` line, which broke the per topic OG (it fell back to the default
+theme) and the site's tag surfaces.
+
+Mitigation: the prompt now says to copy `tags` and `coverImage` verbatim, and a deterministic step re
+inserts the canonical tags line if it is missing. Implemented in `src/lib/post-integrity.ts`
+(`reinsertCanonicalTags`), run via `bun run fix:post-integrity` (DoD-5).
+
+## F5. Tool call leakage into files
+
+A drafting agent once wrote its own tool call markup into the end of an MDX file, breaking the MDX
+parse.
+
+Mitigation: `verify-post` greps for stray markup and confirms the file ends cleanly; DoD-7 (render
+check) catches the rest.
+
+## F6. Uppercase frontmatter keys (whole site build crash)
+
+Discovered 2026-07-08 during the full-chain retest. Groq intermittently echoes the prompt's uppercase
+reference block (`TITLE:`, `DESCRIPTION:`, `DATE:`) as the actual output frontmatter keys. Because
+`parseFrontmatter` in `src/lib/blog.ts` is case sensitive, `metadata.title` then resolves to `undefined`,
+and `src/lib/related-posts.ts` calls `tokenize(metadata.title)` unguarded during the build prerender, so
+`undefined.toLowerCase()` throws and `bun run build` exits non zero for the WHOLE site, not just the one
+page. One bad translation can block the entire deploy.
+
+Mitigation: the deterministic step `normalizeFrontmatterKeyCasing` in `src/lib/post-integrity.ts` rewrites
+any case variant of a known frontmatter key back to its canonical lowercase form (values untouched, body
+untouched), run via `bun run fix:post-integrity`. Since `translate-post` already mandates the fixer after
+every translation, the crashing case can no longer reach the build. Prompts are unreliable for this at
+temperature 0.2, so the guard is code, not prose.

--- a/.claude/skills/draft-post-pl/SKILL.md
+++ b/.claude/skills/draft-post-pl/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: draft-post-pl
+description: Use when writing the canonical Polish pl.mdx for a chosen dev.paczesny.pl blog topic in the author's voice.
+---
+
+# Draft Post (Polish)
+
+Write `content/posts/<slug>/pl.mdx`: the canonical Polish source, in Bartek's voice, from a chosen topic.
+Polish is canonical; the other languages are generated from this file later. The whole product is that
+the post reads like a real person's struggle, not like AI. Voice authenticity is the core value, so this
+skill is the one most likely to fail on "looks right." Do not trust a first draft.
+
+## 1. Frontmatter
+
+Write valid frontmatter with exactly these keys, mirroring the existing posts:
+
+| Key | Rule |
+|---|---|
+| `title` | The post title, in voice. |
+| `description` | At most 160 characters. |
+| `date` | ISO 8601, for example `2026-07-06T12:00:00.000Z`. |
+| `tags` | Comma separated, matching the style of existing posts' `tags` lines. |
+
+Do NOT add a `coverImage` key. Its absence is what makes the post use the dynamic per topic OG route.
+Adding it opts the post out of the OG generator, which is wrong for a new post.
+
+Shape to match (from a real post):
+
+```yaml
+---
+title: "Chcialem przepisac bloga na hype'owy framework i dlaczego sie wypisalem"
+description: "Wpadl mi w oko Fresh na Deno i chcialem przepisac na niego bloga. Policzylem koszt. Wypisalem sie."
+date: 2026-07-06T12:00:00.000Z
+tags: nextjs, framework, deno, fresh, architektura, seo, decyzje, webdev
+---
+```
+
+## 2. Voice
+
+Non negotiable, from the project `CLAUDE.md`:
+
+- Casual Polish, first person, written as a live struggle journey.
+- Numbered goals near the top (a "co chce zrobic" / "dostaniesz trzy rzeczy" list).
+- Slang and profanity are welcome. It must NOT read as polished AI prose.
+- Real specifics and real code where relevant, never invented numbers or fake commands.
+- Ends on an ironic lesson.
+- Any tool mention (for example Paczesny Analytics) is incidental only, never a sales pitch.
+
+Imitate the most recent published post, not an abstract "good writing" standard. When in doubt, copy the
+rhythm, section shapes, and register of that post.
+
+## 3. Structure and depth (show the receipts, match the real posts)
+
+Depth comes from concreteness, NOT from length, an arbitrary word count, or compressing everything into
+abbreviations. A generic, hastily summarized post is a failed draft even when the voice is close. Bartek
+has rejected exactly this ("bardzo generyczny i pospiesznie napisany, strasznie duzo skrotow"). Match the
+shape the existing posts actually have:
+
+- **Show the receipts.** Pull real, concrete evidence from the actual repo and git history: real file
+  counts, real diffs, real code blocks with real file paths, real tables, real commit hashes, real
+  numbers. Do not narrate a summary of what happened; show what happened. Read `content/posts/` and run
+  `git log` / `git show` to extract the real material BEFORE drafting. If a claim cannot be substantiated
+  with something real from the repo, cut it. Never invent numbers or commands.
+- **FAQ section (required).** After the main body, include a `## FAQ` with 4 to 5 real question and answer
+  pairs in the post's own voice: the questions a reader would actually ask, not generic filler.
+- **Linki section (required).** End with a `## Linki` section: a bulleted list of references, both
+  internal `/blog/<lang>/<slug>` links and external URLs, matching the pattern in the existing posts.
+- **Honest counter-argument (when applicable).** If the topic carries a decision or a claim, include a
+  section before the wrap-up that honestly argues the other side ("kiedy X MIALby sens", when the other
+  option actually makes sense). This is what keeps a post from reading like a pitch. The real posts always
+  do it.
+
+Before drafting, open the newest post (section 4 resolves which one) and copy its actual section
+skeleton: cold personal hook, numbered goals list, body carried by receipts, honest counter-argument,
+wrap-up on an ironic lesson, FAQ, Linki.
+
+## 4. Resolve the voice imitation target (compute, do not hardcode)
+
+"The most recent published post" is resolved by frontmatter `date`, sorted descending, NOT by file mtime
+and NOT by git commit order. Compute it every run, because the target changes as new posts land.
+
+```bash
+for f in content/posts/*/pl.mdx; do
+  d=$(grep -m1 '^date:' "$f" | cut -d: -f2- | tr -d ' "')
+  printf '%s\t%s\n' "$d" "$f"
+done | sort -r | head -1
+```
+
+ISO 8601 dates sort lexicographically in chronological order, so `sort -r` on the date column gives the
+newest post. As of writing this resolves to `why-i-didnt-rewrite-my-blog-to-a-new-framework`, but do not
+hardcode that: always recompute, and read that post as the voice reference before drafting.
+
+## 5. Voice guard (mandatory)
+
+Before this draft is considered done:
+
+1. Invoke `creative-writing-skills:llm-writing` and revise the draft until it no longer reads as AI prose.
+   This guard is doubly locked: the project `CLAUDE.md` and the build spec both require it.
+2. Mechanically reject any em dash (Unicode U+2014). Polish and English alike: commas, periods, colons
+   only. Grep the file and fix every hit before finishing.
+3. Reject named AI tells, in either language. If you see them, rewrite:
+   - "let's dive in", "in conclusion", "in today's fast paced world"
+   - "zanurzmy sie", "podsumowujac na wstepie", "w dzisiejszym swiecie"
+   - hollow transitions that restate the previous sentence, and corrections of a misconception nobody has.
+
+If, after honest revision, the draft still cannot be made to pass the voice guard, do NOT ship it
+silently. Flag it for human attention in the PR (say what is off and why) so Bartek can take the voice by
+hand. A flagged draft is acceptable; a silently AI sounding one is not.
+
+## 6. Final self-check (before done)
+
+Do not call the draft done until all of these are true, checked against the shape of the existing posts
+in `content/posts/`:
+
+- Real extracted evidence is present (actual numbers, diffs, code, file paths, commit hashes), not
+  described in the abstract.
+- A `## FAQ` section with 4 to 5 real question and answer pairs is present.
+- A `## Linki` section is present.
+- An honest counter-argument section is present, if the topic has a decision or claim to argue against.
+- Zero em dashes, and the `creative-writing-skills:llm-writing` guard passed.
+- It reads like the newest post, not generic or rushed.
+
+## Output
+
+`content/posts/<slug>/pl.mdx`: correct frontmatter with no `coverImage`, in the author's voice, having
+passed the `creative-writing-skills:llm-writing` guard, or explicitly flagged for human attention when it
+could not.

--- a/.claude/skills/open-post-pr/SKILL.md
+++ b/.claude/skills/open-post-pr/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: open-post-pr
+description: Use when opening a reviewable PR for a completed dev.paczesny.pl post after all publish gates pass.
+---
+
+# Open Post PR
+
+Create a `claude/`-prefixed branch, commit the post files in logical units, and open a PR targeting `dev`.
+This is the terminal skill in the chain. It never merges and never pushes to `dev` or `prod`. Publishing
+is always a human action: Bartek reads the PR, then merges and ships himself. Never push a post live
+without his explicit OK (Repo B `CLAUDE.md`).
+
+## Input
+
+| Field | Value |
+|---|---|
+| slug | The post directory name under `content/posts/`. |
+| verify-post report | The pass/fail gate report, passed in. Its DoD checklist goes verbatim into the PR body. |
+
+## Procedure
+
+1. Create the branch and commit in logical units:
+
+   ```bash
+   git checkout -b claude/post-<slug>
+   git add content/posts/<slug>/pl.mdx && git commit -m "post(<slug>): draft pl"
+   git add content/posts/<slug>/{en,de,fr}.mdx && git commit -m "post(<slug>): translations en, de, fr"
+   # one more commit only if the integrity fixer changed files:
+   git add content/posts/<slug> && git commit -m "post(<slug>): integrity fixes"
+   ```
+
+   One commit per logical unit: the draft, the translations, and any integrity fixes. Only the branch is
+   pushed, and only a `claude/`-prefixed branch. Never `dev`, never `prod`.
+
+2. Open the PR against `dev`. There is no `.github` PR template in this repo, so construct the full body
+   yourself:
+
+   ```bash
+   gh pr create --base dev --head claude/post-<slug> --title "post: <title>" --body-file <body>
+   ```
+
+   The PR body must carry, in this order:
+   - **tl;dr:** one or two lines on what the post is.
+   - **DoD checklist:** every gate with pass or fail, taken verbatim from the verify-post report.
+   - **Internal links added:** the list of internal `/blog/<lang>/<slug>` links the post introduces.
+   - **Verification evidence:** the concrete results (all four pages returned 200, OG resolved per
+     language, slugs canonical, tags identical across languages, no stray markup).
+   - **OG image preview (per language):** a direct reference to the generated OG image for each of pl,
+     en, de, fr, the same `/og/post?title=<title>&lang=<lang>&tags=<tags>` URL that verify-post's DoD-6
+     check hit (or a link to the local render). This is a visibility item, not a new gate: Bartek reviews
+     OG images by eye and compares them against the recent posts, so give him the links to glance at how
+     each card actually looks, not just a pass line.
+
+3. Prepare the Slack summary content: the PR link, the tl;dr, and the DoD summary. This skill produces
+   that content as structured output only. It does NOT call a Slack webhook: none exists in Repo B, and
+   actual Slack delivery is a routine concern (Phase 2 or 3), not this skill's job.
+
+## Hard rules
+
+- Never merge the PR. Only Bartek merges.
+- Never push to `dev` or `prod`, directly or via the PR. Only the `claude/post-<slug>` branch is pushed.
+- The human publish gate is mandatory. The PR targets `dev` and stops there.
+
+## Output
+
+The open PR to `dev` and the prepared Slack summary content (PR link, tl;dr, DoD summary).

--- a/.claude/skills/propose-topics/SKILL.md
+++ b/.claude/skills/propose-topics/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: propose-topics
+description: Use when generating candidate blog post ideas for dev.paczesny.pl grounded in the repo's real recent activity, or when the weekly ideation routine runs.
+---
+
+# Propose Topics
+
+Ideation for the dev.paczesny.pl blog. Read the repo's real recent activity, then propose a few grounded
+post ideas or honestly report that nothing this week is worth writing. You produce the structured
+candidate list only. Posting it to Slack is the routine's job, not yours.
+
+Never invent a topic. Every idea must anchor to a real, verifiable event from the signal you collected.
+An honest empty result beats manufactured filler.
+
+## 1. Collect the signal (read only)
+
+Read, never write, in this step:
+
+1. `git log` for the window (default: since the last run, else the last 7 days). Pull commit messages,
+   changed files, and merged PR titles. This is what actually happened.
+2. `content/posts/` slugs and each post's frontmatter (`title`, `description`, `date`, `tags`). This is
+   what the blog already covers, and the dedup surface for step 4.
+
+Example grounding pass:
+
+```bash
+git log --since="7 days ago" --pretty=format:"%h %s" --name-only
+ls content/posts/
+for f in content/posts/*/pl.mdx; do grep -H -m1 '^title:' "$f"; done
+```
+
+## 2. Decide: did something real happen?
+
+Look at the signal and judge honestly.
+
+| Situation | Output |
+|---|---|
+| Real, publish worthy activity: a bug fought, a feature shipped, a tool built, a decision made | Proceed to step 3, produce 3 to 5 candidates. |
+| Nothing genuinely new, or only trivial churn (deps, typos, formatting) | Return the empty result. Say "nothing worth writing this week" and name what you looked at and why none of it qualified. |
+
+The empty result is a first-class success, not a failure. This blog is not a content mill. Do not
+stretch a weak signal into a fake topic just to fill the list.
+
+## 3. Produce 3 to 5 candidates
+
+Each candidate carries exactly these six fields:
+
+| Field | Meaning |
+|---|---|
+| `title` | The working post title, in the blog's voice. |
+| `angle` | One line: the specific take, not a generic topic label. |
+| `why_now` | The real, verifiable event from step 1 that anchors this idea. Never invented. Point at the actual commit, PR, or shipped thing. |
+| `tags` | Candidate tags, matching the style of the existing posts' `tags` lines. |
+| `promotes_tool` | Nullable. A tool the topic genuinely touches (for example Paczesny Analytics). Incidental only, never a reason to pick the topic. |
+| `is_update_of` | Nullable. An existing slug, set when this is better as an update to that post than a new one (see step 4). |
+
+`promotes_tool` is never a selection criterion. A topic is chosen because it is real and worth writing,
+not because it mentions a product.
+
+## 4. Deduplicate against existing posts
+
+Compare each candidate against the `content/posts/` slugs and frontmatter you read in step 1.
+
+- If a candidate is genuinely new, leave `is_update_of` null.
+- If a candidate is too close to an existing post (same subject, would overlap heavily), do not propose a
+  duplicate. Set `is_update_of` to that existing slug and frame the idea as an update instead of a new
+  post.
+
+## Output
+
+The structured candidate list (3 to 5 items, six fields each), or the explicit empty result with its
+honest reason. That is the whole output. The routine posts it to Slack; you do not.

--- a/.claude/skills/translate-post/SKILL.md
+++ b/.claude/skills/translate-post/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: translate-post
+description: Use when generating en/de/fr translations of a dev.paczesny.pl post from its canonical Polish source.
+---
+
+# Translate Post
+
+Generate the `en`, `de`, and `fr` translations of a post from its canonical `pl.mdx`, then run the
+deterministic integrity fixer on each. You wrap the existing pipeline; you do NOT reimplement the Groq
+call. The translation client lives in `src/lib/translator.ts` and is invoked through
+`bun run translate:post`. Do not modify that file.
+
+Cross-reference the known failure patterns in [`_shared/failure-modes.md`](../_shared/failure-modes.md):
+F1 (daily cap), F2 (per-minute cap), F3 (slug bug), F4 (dropped tags).
+
+## Input
+
+| Field | Value |
+|---|---|
+| slug | The post directory name under `content/posts/`. |
+| target languages | Default `en`, `de`, `fr`. |
+
+Do NOT translate to `es`. Phase 1 scope is exactly `pl, en, de, fr`. The repo i18n also lists `es`, but
+no post is translated to it yet, so leave it out.
+
+## Procedure (per language)
+
+1. Run the existing CLI, one language at a time:
+
+   ```bash
+   bun run translate:post --slug <slug> --lang <en|de|fr>
+   ```
+
+   This calls Groq `llama-3.3-70b-versatile` via `scripts/translate.ts` and `src/lib/translator.ts`,
+   writing `<lang>.mdx` next to `pl.mdx`. Do not reimplement the Groq call or the prompt.
+
+2. Immediately run the deterministic fixer on the file that just landed:
+
+   ```bash
+   bun run fix:post-integrity --slug <slug> --lang <lang>
+   ```
+
+   This rewrites any translated (non-canonical) internal slug back to the real directory name (F3, DoD-4)
+   and re-inserts a dropped or divergent `tags` line (F4, DoD-5). It is deterministic code from
+   `src/lib/post-integrity.ts`, not a prompt. Alternatively hand off to `verify-post`, which runs the same
+   fixer. Prompts are not reliable for F3 and F4, so this step is mandatory, not advisory.
+
+## Rate limits
+
+| Failure mode | Numbers | Handling |
+|---|---|---|
+| F2 per-minute cap | TPM 12000 per minute; output cap already 6000 in `translator.ts` | Space back-to-back requests about 65 seconds apart. On HTTP 429, read and honor the Groq `retry-after` header rather than a blind fixed sleep, then retry with backoff. Do not lower the output cap; it is already set. |
+| F1 daily cap | TPD 100000 per day | Detect the "tokens per day" error explicitly. When hit, do not block for a day: translate the remaining languages with the running agent's own model instead, still enforcing canonical slugs and intact tags (run `fix:post-integrity` on those files too). |
+
+## Provenance report
+
+Report which languages came from the Groq path and which from the agent-model fallback path (F1). For
+example: `en, de from Groq; fr from agent fallback (Groq TPD hit)`. This makes the source of each
+translation auditable downstream.
+
+## Output
+
+`en.mdx`, `de.mdx`, `fr.mdx` written next to `pl.mdx`, each passed through `fix:post-integrity`, plus the
+per-language provenance report.

--- a/.claude/skills/verify-post/SKILL.md
+++ b/.claude/skills/verify-post/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: verify-post
+description: Use when checking a dev.paczesny.pl post against every publish gate before opening a PR, or when a translation may have broken slugs, tags, or rendering.
+---
+
+# Verify Post
+
+The publish-gate sweep. Run every Definition of Done gate against a post. Auto-fix the only two gates
+that are deterministically fixable (DoD-4 slugs, DoD-5 tags) via `bun run fix:post-integrity`; hard-fail
+every other gate. The pass or fail report you produce is used verbatim in the PR body by `open-post-pr`,
+and any hard fail blocks the PR.
+
+Run every gate in [`_shared/definition-of-done.md`](../_shared/definition-of-done.md). Cross-reference
+[`_shared/failure-modes.md`](../_shared/failure-modes.md) for F3 (slug bug), F4 (dropped tags), and F5
+(stray markup).
+
+## Input
+
+The `slug`. The four post files live at `content/posts/<slug>/{pl,en,de,fr}.mdx`.
+
+## Gates
+
+| Gate | Check | Disposition |
+|---|---|---|
+| DoD-2 Completeness | `pl`, `en`, `de`, `fr` all exist. Exactly these four; do NOT require `es`. | hard fail |
+| DoD-3 No truncation | Each translation is at least 70 percent of the `pl` word count and ends on a complete section, AND every `##` section header present in `pl.mdx` is also present in the translation (see below). | hard fail |
+| DoD-4 Canonical slugs | Every internal link `](/blog/<lang>/<slug>)` uses a slug that is a real `content/posts/` directory. Validate against `getPostSlugs()` in `src/lib/blog.ts`, the source of truth, not a regex guess. | AUTO-FIX: run `bun run fix:post-integrity --slug <slug> --lang <lang>` per language |
+| DoD-5 Tags | `tags` line present and identical across all four languages. | AUTO-FIX: the same fixer re-inserts the canonical tags line |
+| DoD-1 Em dashes | Zero em dashes anywhere (mechanical). An em dash present after the draft stage is a failure. | hard fail |
+| F5 Stray markup and secrets | Grep for tool-call markup or stray fragments and confirm each file ends cleanly. Also grep for secret-shaped strings (anything resembling a `GROQ_API_KEY` value) so a secret can never reach a PR. | hard fail if found |
+| DoD-6 OG | `coverImage` absent (dynamic OG) or points to a real file. Run the OG check PER LANGUAGE (see below). Confirm `og:image` returns 200 and resolves to the intended topic theme. | hard fail |
+| DoD-7 Renders | Every one of the four pages and the OG route return HTTP 200 from an in-session build. | hard fail |
+| DoD-8 Frontmatter | `description` at most 160 chars, valid `date`, well-formed `tags`. | hard fail |
+
+DoD-9 (post-deploy sitemap) is Phase D and is NOT run here.
+
+## DoD-3 also compares section headers, not just word count
+
+The word-count ratio is not enough. On a long post the translator can silently drop a whole trailing
+section (for example `## Linki`) while the rest of the translation is verbose enough to still clear the 70
+percent bar and still end on a complete section, so a word-count-only check passes a truncated post. So
+also compare the SET of `##` section headers between the canonical `pl.mdx` and each translation. Count
+the number of `##` headers in each; any header count in a translation that is lower than in `pl.mdx`, or
+any `pl` section missing from a translation, is a dropped section and a hard fail.
+
+```bash
+# per language: pl header count vs translation header count
+plh=$(grep -cE '^## ' content/posts/<slug>/pl.mdx)
+for lang in en de fr; do
+  th=$(grep -cE '^## ' content/posts/<slug>/${lang}.mdx)
+  [ "$th" -lt "$plh" ] && echo "${lang}: dropped section, ${th} of ${plh} headers, HARD FAIL"
+done
+```
+
+This is a DETECTION improvement only. It does NOT fix the translator's tendency to truncate very long
+posts under its output token cap; that remains a known, separate limitation, documented and not resolved
+in this phase. When it fires, the fix is to re-translate the affected language (or shorten the source),
+not to paper over the missing section.
+
+## DoD-4 and DoD-5 are deterministic, not advisory
+
+Prompts do not reliably prevent F3 (translated slugs) and F4 (dropped tags), so these two gates are fixed
+by code, not by asking the model to be careful:
+
+```bash
+bun run fix:post-integrity --slug <slug> --lang <lang>   # run per language after translation
+```
+
+Every other gate is a hard fail: do not auto-fix it, fix the source or block the PR.
+
+## DoD-6 OG check runs PER LANGUAGE
+
+A dropped or altered tag in a single translation (F4) makes only that language's OG image fall back to
+the wrong theme, so a `pl`-only check would miss it. Check each of `pl`, `en`, `de`, `fr`.
+
+Validate the theme against the ACTUAL resolver logic (the `THEMES` array in `src/app/og/post/route.tsx`,
+`pickTheme` is first-match-wins over lowercased tags), or against the actually rendered image. Do NOT
+trust the code comment: the `framework` theme's `match` array includes `nextjs` even though a comment
+near the top of `THEMES` says shared tags like `nextjs` are not used as triggers. Trust the array, not
+the comment.
+
+## DoD-7 render check (one command)
+
+Run the wrapper, which builds the site, starts a local server, and curls all four pages plus the OG route,
+asserting HTTP 200 for each. In-session per decision D8, never a Coolify preview.
+
+```bash
+scripts/verify-post-render.sh <slug>
+```
+
+## Output
+
+A pass or fail line per gate, used verbatim in the PR body by `open-post-pr`. Any hard fail blocks the PR.
+Report which gates were auto-fixed (DoD-4, DoD-5) and what changed.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "translate:top": "tsx scripts/pretranslate.ts",
     "translate:post": "tsx scripts/translate.ts",
+    "fix:post-integrity": "tsx scripts/fix-integrity.ts",
     "describe:post": "tsx scripts/describe.ts",
     "test": "vitest run"
   },

--- a/scripts/fix-integrity.ts
+++ b/scripts/fix-integrity.ts
@@ -1,0 +1,126 @@
+import fs from "fs"
+import { CANONICAL_LANG, SUPPORTED_LANGS, type SupportedLang } from "@/lib/i18n"
+import { getPostFilePath, getPostSlugs, parseFrontmatter } from "@/lib/blog"
+import { fixPostIntegrity } from "@/lib/post-integrity"
+
+function parseArgs() {
+  const argv = process.argv.slice(2)
+  let slug: string | undefined
+  let lang: string | undefined
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i]
+    if (!token) {
+      continue
+    }
+
+    if (token === "--slug" || token === "-s") {
+      slug = argv[i + 1]
+      i += 1
+      continue
+    }
+
+    if (token.startsWith("--slug=")) {
+      slug = token.split("=")[1]
+      continue
+    }
+
+    if (token === "--lang" || token === "-l") {
+      lang = argv[i + 1]
+      i += 1
+      continue
+    }
+
+    if (token.startsWith("--lang=")) {
+      lang = token.split("=")[1]
+      continue
+    }
+  }
+
+  return { slug, lang }
+}
+
+function assertParams({ slug, lang }: { slug?: string; lang?: string }): {
+  slug: string
+  targetLang: SupportedLang
+} {
+  if (!slug) {
+    throw new Error(
+      "Missing --slug argument. Usage: bun run fix:post-integrity --slug my-post --lang en"
+    )
+  }
+
+  if (!lang) {
+    throw new Error(
+      "Missing --lang argument. Usage: bun run fix:post-integrity --slug my-post --lang en"
+    )
+  }
+
+  const normalizedLang = lang.toLowerCase()
+  if (!SUPPORTED_LANGS.includes(normalizedLang as SupportedLang)) {
+    throw new Error(
+      `Unsupported language: ${lang}. Supported languages: ${SUPPORTED_LANGS.join(
+        ", "
+      )}`
+    )
+  }
+
+  return { slug, targetLang: normalizedLang as SupportedLang }
+}
+
+function main() {
+  const { slug, lang } = parseArgs()
+  const { slug: parsedSlug, targetLang } = assertParams({ slug, lang })
+
+  // Read the canonical Polish source for the authoritative tags. File I/O lives
+  // here in the CLI; the fixer library itself stays pure.
+  const canonicalPath = getPostFilePath(parsedSlug, CANONICAL_LANG)
+  if (!canonicalPath) {
+    console.error(
+      `✗ No canonical ${CANONICAL_LANG.toUpperCase()} source found for slug: ${parsedSlug}`
+    )
+    process.exitCode = 1
+    return
+  }
+
+  const targetPath = getPostFilePath(parsedSlug, targetLang)
+  if (!targetPath) {
+    console.error(
+      `✗ No ${targetLang.toUpperCase()} file found for slug: ${parsedSlug}`
+    )
+    process.exitCode = 1
+    return
+  }
+
+  const canonicalRaw = fs.readFileSync(canonicalPath, "utf-8")
+  const canonicalTags = parseFrontmatter(canonicalRaw).metadata.tags ?? []
+  const knownSlugs = getPostSlugs()
+
+  const targetContent = fs.readFileSync(targetPath, "utf-8")
+  const result = fixPostIntegrity(parsedSlug, targetContent, {
+    knownSlugs,
+    canonicalTags,
+  })
+
+  if (!result.changed) {
+    console.log(
+      `✓ ${parsedSlug} ${targetLang.toUpperCase()}: no fixes needed`
+    )
+    return
+  }
+
+  fs.writeFileSync(targetPath, result.content, "utf-8")
+  console.log(
+    `✓ ${parsedSlug} ${targetLang.toUpperCase()}: applied ${result.fixes.length} fix(es)`
+  )
+  result.fixes.forEach((fix) => {
+    console.log(`  - ${fix}`)
+  })
+}
+
+try {
+  main()
+} catch (error) {
+  console.error(`✗ Failed fixing post integrity:`, (error as Error).message)
+  process.exitCode = 1
+}

--- a/scripts/verify-post-render.sh
+++ b/scripts/verify-post-render.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# In-session render check for DoD-7. Builds the site, starts a local server, and
+# curls all four language pages plus the OG route, asserting HTTP 200 for each.
+# This is the in-session check per decision D8, never a Coolify preview.
+#
+# Note: bun 1.2.4 local vs bun@1.2.5 pinned in package.json is expected and
+# non-blocking. Only investigate a version mismatch if the build itself fails in
+# a version shaped way.
+#
+# Usage: scripts/verify-post-render.sh <slug>
+set -euo pipefail
+
+SLUG="${1:-}"
+if [ -z "$SLUG" ]; then
+  echo "usage: scripts/verify-post-render.sh <slug>" >&2
+  exit 2
+fi
+
+PORT=3000
+BASE="http://localhost:${PORT}"
+LANGS="pl en de fr"
+SERVER_PID=""
+
+cleanup() {
+  # Always stop the background server. Guarded so a missing process never fails
+  # the run.
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+  fi
+  pkill -f "next start" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "==> bun install"
+bun install
+
+echo "==> bun run build"
+bun run build
+
+echo "==> starting local server on :${PORT}"
+bun run start >/tmp/verify-post-render-server.log 2>&1 &
+SERVER_PID=$!
+
+# Wait for readiness (up to ~60 seconds).
+ready=""
+for _ in $(seq 1 60); do
+  if curl -sf -o /dev/null "http://localhost:3000/blog/pl/${SLUG}"; then
+    ready="yes"
+    break
+  fi
+  sleep 1
+done
+if [ -z "$ready" ]; then
+  echo "FAIL: server did not become ready on ${BASE}" >&2
+  exit 1
+fi
+
+fail=0
+
+check_url() {
+  url="$1"
+  code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || true)
+  if [ "$code" = "200" ]; then
+    echo "  ok   200  $url"
+  else
+    echo "  FAIL ${code}  $url" >&2
+    fail=1
+  fi
+}
+
+frontmatter_value() {
+  # $1 file, $2 key. First matching frontmatter line, key and surrounding quotes
+  # stripped.
+  grep -m1 "^${2}:" "$1" 2>/dev/null | cut -d: -f2- | sed 's/^[[:space:]]*//; s/^"//; s/"$//' || true
+}
+
+echo "==> checking the four language pages"
+for lang in $LANGS; do
+  check_url "http://localhost:3000/blog/${lang}/${SLUG}"
+done
+
+echo "==> checking the OG route per language"
+for lang in $LANGS; do
+  file="content/posts/${SLUG}/${lang}.mdx"
+  title="bpaczesny's blog"
+  tags=""
+  if [ -f "$file" ]; then
+    t=$(frontmatter_value "$file" "title")
+    [ -n "$t" ] && title="$t"
+    tags=$(frontmatter_value "$file" "tags")
+  fi
+  code=$(curl -s -G -o /dev/null -w "%{http_code}" \
+    --data-urlencode "title=${title}" \
+    --data-urlencode "lang=${lang}" \
+    --data-urlencode "tags=${tags}" \
+    "http://localhost:3000/og/post" || true)
+  if [ "$code" = "200" ]; then
+    echo "  ok   200  ${BASE}/og/post (lang=${lang})"
+  else
+    echo "  FAIL ${code}  ${BASE}/og/post (lang=${lang})" >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "RENDER CHECK FAILED" >&2
+  exit 1
+fi
+
+echo "RENDER CHECK PASSED: all four pages and the OG route returned 200"

--- a/src/lib/post-integrity.test.ts
+++ b/src/lib/post-integrity.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest"
+
+import { fixPostIntegrity } from "@/lib/post-integrity"
+
+describe("fixPostIntegrity", () => {
+  it("rewrites a mangled self-link and re-inserts a dropped tags line", () => {
+    const content = [
+      "---",
+      "title: Proxmox Teil zwei",
+      'description: "Zweiter Teil der Kaempfe mit Proxmox"',
+      "date: 2025-11-15T18:00:00.000Z",
+      "---",
+      "",
+      "Lies zuerst den [zweiten Teil](/blog/de/proxmox-teil-zwei).",
+      "",
+      "Und den [ersten Teil](/blog/de/proxmox-first-install).",
+      "",
+    ].join("\n")
+
+    const result = fixPostIntegrity("proxmox-czesc-druga", content, {
+      knownSlugs: ["proxmox-czesc-druga", "proxmox-first-install"],
+      canonicalTags: ["nextjs", "proxmox"],
+    })
+
+    expect(result.changed).toBe(true)
+    // The mangled self-link is rewritten back to the canonical directory name.
+    expect(result.content).toContain("](/blog/de/proxmox-czesc-druga)")
+    expect(result.content).not.toContain("proxmox-teil-zwei")
+    // The real other post link is left alone.
+    expect(result.content).toContain("](/blog/de/proxmox-first-install)")
+    // The dropped tags line is re-inserted verbatim from the canonical tags.
+    expect(result.content).toContain("tags: nextjs, proxmox")
+
+    const slugFixes = result.fixes.filter((fix) => fix.startsWith("slug"))
+    const tagFixes = result.fixes.filter((fix) => fix.startsWith("tags"))
+    expect(slugFixes).toHaveLength(1)
+    expect(tagFixes).toHaveLength(1)
+  })
+
+  it("returns changed false and byte-identical content when nothing is wrong", () => {
+    const content = [
+      "---",
+      "title: Proxmox Teil zwei",
+      'description: "Zweiter Teil der Kaempfe mit Proxmox"',
+      "date: 2025-11-15T18:00:00.000Z",
+      "tags: nextjs, proxmox",
+      "---",
+      "",
+      "Lies den [ersten Teil](/blog/de/proxmox-first-install).",
+      "Und den [zweiten Teil](/blog/de/proxmox-czesc-druga).",
+      "",
+    ].join("\n")
+
+    const result = fixPostIntegrity("proxmox-czesc-druga", content, {
+      knownSlugs: ["proxmox-czesc-druga", "proxmox-first-install"],
+      canonicalTags: ["nextjs", "proxmox"],
+    })
+
+    expect(result.changed).toBe(false)
+    expect(result.fixes).toEqual([])
+    expect(result.content).toBe(content)
+  })
+
+  it("never rewrites a valid slug that is a substring of the canonical one, and throws on missing frontmatter", () => {
+    const content = [
+      "---",
+      "title: Proxmox Teil zwei",
+      "description: Zweiter Teil",
+      "date: 2025-11-15T18:00:00.000Z",
+      "tags: nextjs, proxmox",
+      "---",
+      "",
+      "Siehe die [Proxmox Serie](/blog/en/proxmox).",
+      "Siehe den [zweiten Teil](/blog/de/proxmox-czesc-druga).",
+      "Kaputt: [hier](/blog/de/proxmox-zweiter-teil).",
+      "",
+    ].join("\n")
+
+    const result = fixPostIntegrity("proxmox-czesc-druga", content, {
+      // "proxmox" is a real other post whose slug is a substring of the canonical slug.
+      knownSlugs: ["proxmox-czesc-druga", "proxmox", "proxmox-first-install"],
+      canonicalTags: ["nextjs", "proxmox"],
+    })
+
+    // Neither the substring slug nor the already-canonical self-link is touched.
+    expect(result.content).toContain("](/blog/en/proxmox)")
+    expect(result.content).toContain("](/blog/de/proxmox-czesc-druga)")
+    // Only the genuinely non-canonical slug is rewritten.
+    expect(result.content).not.toContain("proxmox-zweiter-teil")
+    expect(result.fixes.filter((fix) => fix.startsWith("slug"))).toHaveLength(1)
+
+    // Malformed input with no frontmatter throws, mirroring parseFrontmatter.
+    expect(() =>
+      fixPostIntegrity("proxmox-czesc-druga", "no frontmatter here", {
+        knownSlugs: ["proxmox-czesc-druga"],
+        canonicalTags: ["nextjs", "proxmox"],
+      })
+    ).toThrow("No frontmatter found")
+  })
+
+  it("normalizes uppercase frontmatter keys to canonical lowercase, preserving values", () => {
+    const content = [
+      "---",
+      "TITLE: My Title With Spaces",
+      'DESCRIPTION: "Some description with: a colon"',
+      "DATE: 2026-07-08T12:00:00.000Z",
+      "tags: nextjs, proxmox",
+      "---",
+      "",
+      "Body [self](/blog/de/proxmox-czesc-druga).",
+      "",
+    ].join("\n")
+
+    const result = fixPostIntegrity("proxmox-czesc-druga", content, {
+      knownSlugs: ["proxmox-czesc-druga"],
+      canonicalTags: ["nextjs", "proxmox"],
+    })
+
+    expect(result.changed).toBe(true)
+    expect(result.content).toContain("title: My Title With Spaces")
+    expect(result.content).toContain(
+      'description: "Some description with: a colon"'
+    )
+    expect(result.content).toContain("date: 2026-07-08T12:00:00.000Z")
+    expect(result.content).not.toMatch(/^TITLE:/m)
+    expect(result.content).not.toMatch(/^DESCRIPTION:/m)
+    expect(result.content).not.toMatch(/^DATE:/m)
+
+    const caseFixes = result.fixes.filter((fix) => fix.startsWith("frontmatter"))
+    expect(caseFixes).toHaveLength(3)
+  })
+
+  it("leaves already-lowercase frontmatter keys untouched (no casing fix)", () => {
+    const content = [
+      "---",
+      "title: Fine",
+      "description: Fine description",
+      "date: 2026-07-08T12:00:00.000Z",
+      "tags: nextjs, proxmox",
+      "---",
+      "",
+      "Body [self](/blog/de/proxmox-czesc-druga).",
+      "",
+    ].join("\n")
+
+    const result = fixPostIntegrity("proxmox-czesc-druga", content, {
+      knownSlugs: ["proxmox-czesc-druga"],
+      canonicalTags: ["nextjs", "proxmox"],
+    })
+
+    expect(
+      result.fixes.filter((fix) => fix.startsWith("frontmatter"))
+    ).toHaveLength(0)
+    expect(result.changed).toBe(false)
+    expect(result.content).toBe(content)
+  })
+
+  it("does not touch keys that only partially match a known key", () => {
+    const content = [
+      "---",
+      "title: Real Title",
+      "titleImage: /assets/x.png",
+      "dateModified: 2026-07-08",
+      "description: desc",
+      "date: 2026-07-08T12:00:00.000Z",
+      "tags: nextjs, proxmox",
+      "---",
+      "",
+      "Body.",
+      "",
+    ].join("\n")
+
+    const result = fixPostIntegrity("proxmox-czesc-druga", content, {
+      knownSlugs: ["proxmox-czesc-druga"],
+      canonicalTags: ["nextjs", "proxmox"],
+    })
+
+    // titleImage and dateModified are not known keys: left exactly as written.
+    expect(result.content).toContain("titleImage: /assets/x.png")
+    expect(result.content).toContain("dateModified: 2026-07-08")
+    expect(
+      result.fixes.filter((fix) => fix.startsWith("frontmatter"))
+    ).toHaveLength(0)
+  })
+})

--- a/src/lib/post-integrity.ts
+++ b/src/lib/post-integrity.ts
@@ -1,0 +1,228 @@
+import { getPostSlugs, parseFrontmatter } from "@/lib/blog"
+
+// Matches an internal blog link of the shape ](/blog/<lang>/<slug>). The <lang>
+// segment is any two letter language code and is left alone; the <slug> segment
+// must be an existing content directory name or it gets rewritten.
+const INTERNAL_LINK_REGEX = /\]\(\/blog\/([a-z]{2})\/([a-z0-9-]+)\)/g
+
+// Matches the leading YAML frontmatter block so tag edits only touch frontmatter,
+// never a stray "tags:" mention in the body. Split into open, inner, close so the
+// surrounding bytes are preserved exactly when nothing needs to change.
+const FRONTMATTER_BLOCK_REGEX = /^(---[ \t]*\r?\n)([\s\S]*?)(\r?\n---)/
+
+// Known frontmatter keys mapped from their lowercased form to the canonical
+// casing the rest of the app (and the case-sensitive parseFrontmatter) expects.
+// The translator sometimes echoes the prompt's uppercase reference block
+// (TITLE:/DESCRIPTION:/DATE:) as the output keys, which makes metadata.title
+// undefined and later crashes the site build. See normalizeFrontmatterKeyCasing.
+const CANONICAL_FRONTMATTER_KEYS: Record<string, string> = {
+  title: "title",
+  description: "description",
+  date: "date",
+  tags: "tags",
+  coverimage: "coverImage",
+  readingtimeminutes: "readingTimeMinutes",
+}
+
+// A single frontmatter key line: leading indent, the bare key name (letters
+// only, so camelCase keys match but hyphenated or suffixed keys do not), then
+// the colon. The value after the colon is never captured, so it is preserved.
+const FRONTMATTER_KEY_LINE_REGEX = /^(\s*)([A-Za-z]+)(\s*:)/
+
+export type PostIntegrityFixResult = {
+  changed: boolean
+  fixes: string[]
+  content: string
+}
+
+export type PostIntegrityOptions = {
+  knownSlugs?: string[]
+  canonicalTags?: string[]
+}
+
+type HelperResult = {
+  content: string
+  fixes: string[]
+}
+
+/**
+ * Deterministic post integrity guard for translated MDX. Rewrites any internal
+ * slug that is not a real content directory back to the canonical slug (DoD-4,
+ * failure mode F3) and re inserts the canonical tags line when the translator
+ * dropped or diverged it (DoD-5, failure mode F4).
+ *
+ * Also normalizes the casing of known frontmatter keys (TITLE: back to title:)
+ * so a translation with uppercased keys cannot crash the build (DoD-8, F6).
+ *
+ * Pure: never touches the filesystem. The CLI caller supplies knownSlugs and
+ * canonicalTags and owns all file I/O. Returns changed false for the already
+ * correct case (content is returned unchanged); throws only for malformed input
+ * with no frontmatter, mirroring parseFrontmatter.
+ */
+export function fixPostIntegrity(
+  canonicalSlug: string,
+  translatedContent: string,
+  options?: PostIntegrityOptions
+): PostIntegrityFixResult {
+  // Validate that frontmatter exists. Throws "No frontmatter found" on malformed
+  // input, reusing the existing parser rather than reimplementing the check.
+  parseFrontmatter(translatedContent)
+
+  const knownSlugs = options?.knownSlugs ?? getPostSlugs()
+  const canonicalTags = options?.canonicalTags ?? []
+
+  const slugResult = rewriteInternalSlugLinks(
+    translatedContent,
+    canonicalSlug,
+    knownSlugs
+  )
+  // Normalize key casing before the tag step, so a divergent-case tags key is
+  // canonicalized first and reinsertCanonicalTags sees the corrected frontmatter.
+  const caseResult = normalizeFrontmatterKeyCasing(slugResult.content)
+  const tagResult = reinsertCanonicalTags(caseResult.content, canonicalTags)
+
+  const fixes = [...slugResult.fixes, ...caseResult.fixes, ...tagResult.fixes]
+
+  return {
+    changed: fixes.length > 0,
+    fixes,
+    content: tagResult.content,
+  }
+}
+
+/**
+ * Rewrite internal blog links whose slug is not a known content directory back
+ * to the canonical slug. A slug that is already a valid member of knownSlugs is
+ * never rewritten, which is the false positive guard: a real other post whose
+ * slug is a substring of the canonical slug stays untouched.
+ */
+function rewriteInternalSlugLinks(
+  content: string,
+  canonicalSlug: string,
+  knownSlugs: string[]
+): HelperResult {
+  const known = new Set(knownSlugs)
+  const fixes: string[] = []
+
+  const rewritten = content.replace(
+    INTERNAL_LINK_REGEX,
+    (match, lang: string, slug: string) => {
+      if (known.has(slug)) {
+        return match
+      }
+      fixes.push(
+        `slug: rewrote /blog/${lang}/${slug} to /blog/${lang}/${canonicalSlug}`
+      )
+      return `](/blog/${lang}/${canonicalSlug})`
+    }
+  )
+
+  return { content: rewritten, fixes }
+}
+
+/**
+ * Normalize the casing of known frontmatter keys back to their canonical form
+ * (for example TITLE: to title:, Description: to description:). Operates only on
+ * the leading frontmatter block, never the body, and rewrites only the key name:
+ * the value after the colon is preserved byte for byte. Matches the key name
+ * case-insensitively and as a whole word, so a partial or suffixed key such as
+ * titleImage: or dateModified: is left untouched. No-op when every known key is
+ * already correctly cased.
+ *
+ * This closes the build-crash failure mode: when the translator echoes the
+ * prompt's uppercase reference block as output keys, parseFrontmatter (which is
+ * case sensitive) yields metadata.title === undefined, and related-posts.ts then
+ * calls tokenize(metadata.title) unguarded during the build prerender, crashing
+ * the entire site build. Running this before the build removes the cause.
+ */
+function normalizeFrontmatterKeyCasing(content: string): HelperResult {
+  const fixes: string[] = []
+
+  const block = FRONTMATTER_BLOCK_REGEX.exec(content)
+  if (!block) {
+    return { content, fixes }
+  }
+
+  const [, open, inner, close] = block
+  const lines = inner.split("\n").map((line) => {
+    const match = FRONTMATTER_KEY_LINE_REGEX.exec(line)
+    if (!match) {
+      return line
+    }
+    const [, indent, rawKey, colon] = match
+    const canonical = CANONICAL_FRONTMATTER_KEYS[rawKey.toLowerCase()]
+    if (!canonical || canonical === rawKey) {
+      return line
+    }
+    fixes.push(`frontmatter: normalized key ${rawKey} to ${canonical}`)
+    return indent + canonical + colon + line.slice(match[0].length)
+  })
+
+  if (fixes.length === 0) {
+    return { content, fixes }
+  }
+
+  const rebuilt =
+    open + lines.join("\n") + close + content.slice(block[0].length)
+
+  return { content: rebuilt, fixes }
+}
+
+/**
+ * Ensure the frontmatter tags line is present and equal to the canonical tags,
+ * comma separated. Replaces a divergent line, inserts a missing one (after the
+ * date line when present), and returns the content unchanged when it already
+ * matches. An empty canonicalTags set means "do not touch tags".
+ */
+function reinsertCanonicalTags(
+  content: string,
+  canonicalTags: string[]
+): HelperResult {
+  const fixes: string[] = []
+
+  if (canonicalTags.length === 0) {
+    return { content, fixes }
+  }
+
+  const currentTags = parseFrontmatter(content).metadata.tags ?? []
+  if (tagsAreEqual(currentTags, canonicalTags)) {
+    return { content, fixes }
+  }
+
+  const block = FRONTMATTER_BLOCK_REGEX.exec(content)
+  if (!block) {
+    // Frontmatter presence is validated by the caller, so this is unreachable in
+    // practice; return unchanged rather than throw a second time.
+    return { content, fixes }
+  }
+
+  const [, open, inner, close] = block
+  const desiredLine = `tags: ${canonicalTags.join(", ")}`
+  const lines = inner.split("\n")
+  const tagsIndex = lines.findIndex((line) => /^\s*tags\s*:/.test(line))
+
+  if (tagsIndex >= 0) {
+    lines[tagsIndex] = desiredLine
+    fixes.push("tags: replaced divergent tags line with canonical tags")
+  } else {
+    const dateIndex = lines.findIndex((line) => /^\s*date\s*:/.test(line))
+    if (dateIndex >= 0) {
+      lines.splice(dateIndex + 1, 0, desiredLine)
+    } else {
+      lines.push(desiredLine)
+    }
+    fixes.push("tags: re-inserted missing canonical tags line")
+  }
+
+  const rebuilt =
+    open + lines.join("\n") + close + content.slice(block[0].length)
+
+  return { content: rebuilt, fixes }
+}
+
+function tagsAreEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  return a.every((tag, index) => tag === b[index])
+}


### PR DESCRIPTION
## tl;dr

Phase 1 of the blog editorial agent: five committed Claude Code skills that automate the mechanical,
error prone parts of publishing to this blog, plus a deterministic integrity fixer that closes the
translation failure modes prompts alone cannot. Nothing here publishes anything: the terminal skill opens
a PR to `dev` and stops, the human gate stays intact.

## What is in this PR

**Five skills** (`.claude/skills/`, auto discovered by any session working this repo, including headless
routines):

- `propose-topics`: grounded ideation over `git log` and existing posts, with an honest "nothing worth
  writing this week" path as a first class success.
- `draft-post-pl`: voice first Polish draft that imitates the newest post by frontmatter date, invokes
  the `creative-writing-skills:llm-writing` guard, and requires real receipts, a `## FAQ`, a `## Linki`
  section, and an honest counter argument, so drafts do not read as generic or rushed.
- `translate-post`: wraps the existing `bun run translate:post` (Groq), handles the daily and per minute
  rate limits, and runs the deterministic fixer after each language.
- `verify-post`: the full Definition of Done gate sweep. Auto fixes only canonical slugs and tags, hard
  fails the rest. DoD-3 now also compares `##` section headers between the source and each translation, so
  a silently dropped section (for example a truncated `## Linki`) is caught, not just a low word count.
- `open-post-pr`: creates a `claude/`-prefixed branch, commits in logical units, and opens a PR to `dev`
  only, with an OG image preview per language in the body. Never merges, never pushes to `dev` or `prod`.

**Two shared reference docs** (`.claude/skills/_shared/`): the nine DoD gates and the six failure modes
F1 through F6, linked by name from the skills instead of repeated in each.

**Deterministic integrity fixer** (`src/lib/post-integrity.ts` plus `post-integrity.test.ts`, the
`scripts/fix-integrity.ts` CLI, and the `package.json` `fix:post-integrity` script). It rewrites non
canonical internal slugs back to the canonical directory (F3), restores a dropped or diverged tags line
(F4), and normalizes uppercase frontmatter keys back to lowercase (F6). F6 matters: an uppercase `TITLE:`
key from the translator made `parseFrontmatter` yield an undefined title, which crashed the whole
`bun run build`. The fixer closes that at the root, and `translate-post` already runs it after every
translation. Covered by 9 Vitest cases.

**Render check helper** (`scripts/verify-post-render.sh`): the in session build plus curl of all four
language pages and the OG route, used by `verify-post` for DoD-7.

## Files

- `.claude/skills/_shared/definition-of-done.md`, `.claude/skills/_shared/failure-modes.md`
- `.claude/skills/{propose-topics,draft-post-pl,translate-post,verify-post,open-post-pr}/SKILL.md`
- `src/lib/post-integrity.ts`, `src/lib/post-integrity.test.ts`
- `scripts/fix-integrity.ts`, `scripts/verify-post-render.sh`
- `package.json` (one added script line: `fix:post-integrity`)

## Testing

Each of the five skills was validated with an application scenario test (a fresh subagent given the skill
plus a realistic input against the real repo), and the full production chain was exercised end to end on a
disposable slug. That testing surfaced and closed two real pipeline defects (the F6 build crash and a
truncation detection gap in DoD-3). The detailed evidence is recorded in this project's planning artifacts,
not pasted here. `bun run test` is green (9 tests). No new dependency is added.

Draft for review, please do not merge. Publishing stays a human action.
