### PR TITLE
feat(ideation): live-feed freshness/streak signal + Slack format for propose-topics

### DIFF
--- a/.claude/skills/propose-topics/SKILL.md
+++ b/.claude/skills/propose-topics/SKILL.md
@@ -29,6 +29,27 @@ ls content/posts/
 for f in content/posts/*/pl.mdx; do grep -H -m1 '^title:' "$f"; done
 ```
 
+## 1b. Check freshness against the live feed
+
+Fetch the public JSON feed and work out how long the blog has gone without a new post. This is the
+freshness and streak signal that grounds the empty result message (D-03, D-04). It is derived fresh on
+every run from the live feed, never from a stored state file and never from re-reading Slack history.
+
+```bash
+curl -s https://dev.paczesny.pl/feed.json | jq -r '.items[0].date_published'
+```
+
+Fetch over HTTPS directly: `http://dev.paczesny.pl` answers with a 302 redirect, so a plain `http://`
+request never reaches the feed. The request itself is a plain unauthenticated GET, the feed is public.
+
+Feed that `date_published` value into the repo's `computeStreak` helper (`src/lib/streak.ts`) to get
+`weeksSinceLastPost` and, when it is 1 or more, a Polish `streakNote` such as
+`2. tydzień z rzędu bez nowego wpisu`. The helper is pure weeks-since arithmetic (`floor(daysSince / 7)`,
+fail closed on a bad date), so call it through the repo toolchain or replicate the same arithmetic inline
+if the session has no build step. If `computeStreak` returns `weeksSinceLastPost` null (a missing or
+unparseable feed date), treat it as no freshness signal available, not as zero weeks: say the freshness
+check could not read the feed, and never report a false all-clear off a bad feed.
+
 ## 2. Decide: did something real happen?
 
 Look at the signal and judge honestly.
@@ -68,5 +89,44 @@ Compare each candidate against the `content/posts/` slugs and frontmatter you re
 
 ## Output
 
-The structured candidate list (3 to 5 items, six fields each), or the explicit empty result with its
-honest reason. That is the whole output. The routine posts it to Slack; you do not.
+You produce the message ready text and its exact format. The routine posts it to Slack; you do not. Keep
+that division intact: never call Slack from this skill.
+
+### Non-empty result: one numbered message
+
+A single numbered list, 1 to 5 items. Each candidate shows its `title`, its one line `angle`, and its
+`why_now` inline, so the author can decide without leaving Slack (D-01). Close with a descriptive call to
+action that carries an example, phrased like "Odpisz 1-5, albo napisz własny temat jeśli żaden nie pasuje"
+(D-02), not a terse one word prompt.
+
+```text
+Tematy na ten tydzień:
+
+1. <title>
+   Angle: <angle>
+   Czemu teraz: <why_now>
+2. <title>
+   Angle: <angle>
+   Czemu teraz: <why_now>
+
+Odpisz 1-5, albo napisz własny temat jeśli żaden nie pasuje.
+```
+
+### Empty result: an honest, first-class success
+
+When nothing qualifies, keep it short but never a bare one liner. Name what you actually checked (the git
+window and the existing posts in `content/posts/`) and why none of it earned a post (D-03). When the
+freshness check from step 1b returned `weeksSinceLastPost` of 1 or more, include its `streakNote` so
+consecutive empty weeks are surfaced (D-04). If step 1b could not read the feed (`weeksSinceLastPost`
+null), say the freshness check was unavailable this run rather than inventing a streak count.
+
+```text
+Nic w tym tygodniu nie łapie się na osobny wpis.
+
+Sprawdziłem: commity z ostatnich 7 dni i tematy już opisane w content/posts/. Same drobne zmiany, nic na
+własny wpis.
+
+2. tydzień z rzędu bez nowego wpisu.
+```
+
+An empty result is a success, not a failure, consistent with step 2. This blog is not a content mill.

--- a/src/lib/streak.test.ts
+++ b/src/lib/streak.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+
+import { computeStreak } from "@/lib/streak"
+
+const NOW = new Date("2026-07-08T00:00:00.000Z")
+
+describe("computeStreak", () => {
+  it("reports no streak when the last post is within the past week", () => {
+    const result = computeStreak("2026-07-06T12:00:00.000Z", { now: NOW })
+
+    expect(result.weeksSinceLastPost).toBe(0)
+    expect(result.streakNote).toBeNull()
+  })
+
+  it("reports one week and a Polish note for a gap of exactly seven days", () => {
+    const result = computeStreak("2026-07-01T00:00:00.000Z", { now: NOW })
+
+    expect(result.weeksSinceLastPost).toBe(1)
+    expect(result.streakNote).not.toBeNull()
+    expect(result.streakNote).toContain("tydzień")
+  })
+
+  it("computes weeks-since correctly for a multi-week gap", () => {
+    const result = computeStreak("2026-06-10T00:00:00.000Z", { now: NOW })
+
+    expect(result.weeksSinceLastPost).toBeGreaterThanOrEqual(4)
+    expect(result.streakNote).not.toBeNull()
+    expect(result.streakNote).toContain("tydzień")
+  })
+
+  it("fails closed on an unparseable date, returning null rather than zero", () => {
+    const result = computeStreak("not-a-date", { now: NOW })
+
+    expect(result.weeksSinceLastPost).toBeNull()
+    expect(result.streakNote).toBeNull()
+  })
+
+  it("treats a missing date as no signal, returning null rather than zero", () => {
+    const result = computeStreak(undefined, { now: NOW })
+
+    expect(result.weeksSinceLastPost).toBeNull()
+    expect(result.streakNote).toBeNull()
+  })
+
+  it("defaults now to the current clock only when options.now is omitted", () => {
+    const result = computeStreak("2020-01-01T00:00:00.000Z")
+
+    expect(result.weeksSinceLastPost).not.toBeNull()
+    expect(result.weeksSinceLastPost as number).toBeGreaterThanOrEqual(1)
+    expect(result.streakNote).toContain("tydzień")
+  })
+})

--- a/src/lib/streak.ts
+++ b/src/lib/streak.ts
@@ -1,0 +1,53 @@
+// Freshness / streak signal for the propose-topics ideation skill.
+//
+// Pure, zero-I/O date arithmetic: given the most recent publish date from the
+// live feed (items[0].date_published) and an injectable "now", it reports how
+// many whole weeks have passed since the last post and a Polish streak note for
+// consecutive empty weeks. The fetch itself lives in the skill step, not here,
+// mirroring the feed.ts (pure) vs feed.json/route.ts (I/O) split, so this stays
+// trivially unit-testable with a fixed now.
+//
+// Fails closed: a missing or unparseable date yields weeksSinceLastPost null
+// (never 0), so a bad feed reads as "no freshness signal", not a false all-clear.
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24
+const DAYS_PER_WEEK = 7
+
+export type StreakResult = {
+  weeksSinceLastPost: number | null
+  streakNote: string | null
+}
+
+export function computeStreak(
+  lastPublishedIso: string | undefined,
+  options?: { now?: Date }
+): StreakResult {
+  const now = options?.now ?? new Date()
+
+  const timestamp = parsePublishedTimestamp(lastPublishedIso)
+  if (timestamp === null) {
+    // Fail closed: an unparseable or missing date is no signal, not zero weeks.
+    return { weeksSinceLastPost: null, streakNote: null }
+  }
+
+  const daysSince = (now.getTime() - timestamp) / MS_PER_DAY
+  // Clamp to 0 so a newest post dated in the future reads as fresh, never negative.
+  const weeksSinceLastPost = Math.max(0, Math.floor(daysSince / DAYS_PER_WEEK))
+
+  const streakNote =
+    weeksSinceLastPost >= 1
+      ? `${weeksSinceLastPost}. tydzień z rzędu bez nowego wpisu`
+      : null
+
+  return { weeksSinceLastPost, streakNote }
+}
+
+// Mirrors getPublishedTimestamp in related-posts.ts: null on missing/unparseable,
+// never a numeric fallback, so callers can distinguish "no signal" from "zero".
+function parsePublishedTimestamp(candidate: string | undefined): number | null {
+  if (!candidate) {
+    return null
+  }
+  const timestamp = Date.parse(candidate)
+  return Number.isNaN(timestamp) ? null : timestamp
+}


### PR DESCRIPTION
## tl;dr

Adds the live-feed freshness/streak signal to the `propose-topics` ideation skill, plus the exact Slack message format the weekly Routine A will post. The freshness logic ships as a pure, unit-tested helper; the message format lives in the skill, not the routine prompt, so wording changes stay normal commits.

## What changed

- `src/lib/streak.ts` (new): pure `computeStreak(lastPublishedIso, { now })` returning `{ weeksSinceLastPost, streakNote }`. Zero I/O (no fetch, no unconditional clock read), so it is trivially unit-testable. Turns the feed's most recent `date_published` into a weeks-since count and a Polish streak note. Fails closed: a missing or unparseable date returns `weeksSinceLastPost` null (never 0) and `streakNote` null, so a bad feed never reports a false all-clear (D-05). Mirrors the `getPublishedTimestamp` fail-closed pattern in `related-posts.ts` and the pure-transform vs I/O split in `feed.ts`.
- `src/lib/streak.test.ts` (new): vitest suite pinning every case with a fixed `now`: within-a-week gap, exactly seven days, multi-week gap, unparseable date, missing date, and the default-now branch. Run with `bun run test -- streak` (6 tests, green). No mocks, no network stubs, matching `related-posts.test.ts`.
- `.claude/skills/propose-topics/SKILL.md` (extended): new "1b. Check freshness against the live feed" step (fetch `https://dev.paczesny.pl/feed.json` over HTTPS, read `items[0].date_published`, feed it to `computeStreak`), and an expanded Output section pinning the numbered 1 to 5 message with title + angle + why_now inline and a descriptive call to action (D-01, D-02), plus an honest empty result that names what was checked and surfaces the streak note for consecutive empty weeks (D-03, D-04). Frontmatter, step 3 candidate fields, and step 4 dedup logic are unchanged.

## Notes for the reviewer

- **Testing:** `computeStreak` is unit-tested (`bun run test -- streak`, 6 cases green). The skill extension is prose; its behavior is exercised when Routine A runs.
- **HTTPS correction:** D-10's "plain HTTP GET" wording is honored as a plain unauthenticated GET over HTTPS. `http://dev.paczesny.pl` answers a 302 redirect, so the skill targets `https://` directly. Minor wording correction, not a scope change.
- **Branch base (deviation from the literal plan):** the plan said to branch off `claude/blog-editorial-skills` because `dev` did not yet contain `.claude/skills/`. That precondition changed: Phase 1's PR #6 is now **merged** into `dev` (squash-merged as `d10b1b1`), so `dev` already carries the base `propose-topics` skill. Because #6 was squash-merged, branching off the old `claude/blog-editorial-skills` tip would push the merge base back before the skills work and re-show all of Phase 1's files in this diff. To give you the clean 3-file diff the plan intended, this branch is cut from `dev` directly (whose tree is byte-identical to `claude/blog-editorial-skills`, so the base skill is inherited unchanged). This PR's diff is therefore exactly the three deliverables above, with no Phase 1 files.

## Guardrails

Not merged, not pushed to `dev` or `prod`. This PR is the human review gate. Zero em dashes in any file or commit message.
