### PR TITLE
post: Zrobiłem, żeby blog sam się upominał na Slacku, kiedy przestaję pisać

### DIFF
--- a/content/posts/i-made-my-blog-nag-me-on-slack/de.mdx
+++ b/content/posts/i-made-my-blog-nag-me-on-slack/de.mdx
@@ -1,0 +1,152 @@
+---
+title: Ich habe einen Bot gebaut, der mich auf Slack erinnert, wenn ich aufhöre zu schreiben
+description: propose-topics zählt jetzt Wochen ohne Beitrag mit einer fail-closed-Funktion und sendet Themen oder ehrliche "nichts in dieser Woche" an #blog-ideas.
+date: 2026-07-09T09:00:00.000Z
+tags: slack, automatyzacja, ideation, typescript, testy, agenci, webhook
+---
+
+## Einleitung
+
+Mittwoch, ich überprüfe, wann ich zuletzt etwas veröffentlicht habe, und anstatt im Kopf zu zählen "also wahrscheinlich eine Woche, vielleicht mehr", mache ich etwas, das noch nie zuvor passiert ist: Ich frage einen Bot, den ich selbst gebaut habe. Denn zwei Tage zuvor habe ich ihm eine Funktion hinzugefügt, die selbst zählt, wie viele Wochen ich schweige, und sich selbst auf Slack erinnert, bevor ich mich überhaupt daran erinnere.
+
+Das ist der Moment, in dem du erkennst, dass du einen Prozess zur Ideengenerierung für deinen Blog hast, aber der gesamte Prozess davon abhängt, dass du dich daran erinnerst, ihn zu starten. Ich hatte den `propose-topics`-Skill, der den Git-Log liest und Themen vorschlägt. Er funktionierte gut. Aber ich musste mir selbst daran erinnern, ihn zu starten, und mich an Dinge zu erinnern, ist genau das, was ich am schlechtesten kann.
+
+Du wirst drei Dinge aus diesem Beitrag erfahren:
+
+1. **Wie `computeStreak` aussieht**, eine reine Funktion, die die Wochen ohne Beitrag zählt, die fail-closed ist, anstatt null zu lügen,
+2. **Warum der Feed-Fetch im Skill und nicht in der Bibliothek lebt**, und warum das kein architektonischer Kapriz ist,
+3. **Wie die Nachricht aussieht, die jetzt selbst auf #blog-ideas landet**, sowohl die Version mit Themen als auch die ehrliche Version "nichts in dieser Woche".
+
+## Ausgangspunkt: Ein Skill, der wartet, bis er aufgerufen wird
+
+`propose-topics` hatte bereits seine Arbeit im Griff: Er las den Git-Log der letzten sieben Tage, sah, was in `content/posts/` war, um Themen nicht zu duplizieren, und produzierte eine Liste von 3 bis 5 Kandidaten oder sagte ehrlich "nichts in dieser Woche passt". Das Problem lag nicht in der Logik. Das Problem lag darin, dass ich der Trigger war. Der Skill wusste nicht, wann ich zuletzt etwas veröffentlicht hatte, also konnte er es mir nicht sagen, bis ich ihn nicht fragte.
+
+Und ich fragte ihn nur, wenn ich mich gerade daran erinnerte. Also selten.
+
+## computeStreak: Eine reine Funktion, null I/O
+
+Die Lösung begann ich mit der langweiligsten möglichen Sache: einer Funktion, die den Datumsunterschied zählt. Die gesamte Logik sitzt in `src/lib/streak.ts`, ohne Fetch, ohne Nebeneffekte, damit sie getestet werden kann, ohne die Hälfte des Internets zu mocken:
+
+```ts
+export function computeStreak(
+  lastPublishedIso: string | undefined,
+  options?: { now?: Date }
+): StreakResult {
+  const now = options?.now ?? new Date()
+
+  const timestamp = parsePublishedTimestamp(lastPublishedIso)
+  if (timestamp === null) {
+    // Fail closed: Ein unparsebares oder fehlendes Datum ist kein Signal, nicht null.
+    return { weeksSinceLastPost: null, streakNote: null }
+  }
+
+  const daysSince = (now.getTime() - timestamp) / MS_PER_DAY
+  const weeksSinceLastPost = Math.max(0, Math.floor(daysSince / DAYS_PER_WEEK))
+
+  const streakNote =
+    weeksSinceLastPost >= 1
+      ? `${weeksSinceLastPost}. Woche in Folge ohne neuen Beitrag`
+      : null
+
+  return { weeksSinceLastPost, streakNote }
+}
+```
+
+Eine Entscheidung hier tut am meisten weh, wenn man von außen hinschaut, aber sie ist die einzige richtige: Wenn `parsePublishedTimestamp` etwas bekommt, das es nicht parsen kann, gibt die Funktion `null` zurück, nicht `0`. Siehst du den Unterschied? Null Wochen bedeutet "du schreibst regelmäßig, alles super". Null bedeutet "ich habe keine Ahnung, weil der Feed mir nicht parsiert". Die Verwechslung dieser beiden in eine Richtung ist ein Bot, der dich für deine Fleißigkeit lobt, wenn er in Wirklichkeit selbst kaputt ist und nichts zu zählen hat. Ich habe das als ersten Test geschrieben, bevor ich überhaupt den Rest in Angriff genommen habe:
+
+```ts
+it("fails closed on an unparseable date, returning null rather than zero", () => {
+  const result = computeStreak("not-a-date", { now: NOW })
+
+  expect(result.weeksSinceLastPost).toBeNull()
+  expect(result.streakNote).toBeNull()
+})
+
+it("treats a missing date as no signal, returning null rather than zero", () => {
+  const result = computeStreak(undefined, { now: NOW })
+
+  expect(result.weeksSinceLastPost).toBeNull()
+  expect(result.streakNote).toBeNull()
+})
+```
+
+Sechs Tests insgesamt in `src/lib/streak.test.ts`, von null Wochen nach einem frischen Beitrag bis hin zu mehrwöchigen Lücken, einschließlich der beiden fail-closed-Fälle und eines, der überprüft, dass `now` standardmäßig den echten Zeitpunkt erfasst, wenn man ihm nichts gibt. Injectable `now` ist kein Schmuck, es ist der einzige Weg, dass der Test auf "eine Woche Pause" nicht anfängt zu flackern, wenn jemand ihn mit einem harten Datum "heute" geschrieben hat.
+
+## Warum der Fetch nicht in derselben Funktion sitzt
+
+Ich könnte den `fetch("https://dev.paczesny.pl/feed.json")` direkt in `computeStreak` einfügen und eine Funktion für alles haben. Ich habe das nicht getan, weil im Repo bereits genau dieselbe Aufteilung an anderer Stelle existiert: `feed.ts` hält die reine Logik des Feed-Baus, und `feed.json/route.ts` macht die I/O und serviert es als Endpoint. `streak.ts` geht denselben Weg, der Fetch bleibt im Skill-Schritt, und die Funktion bekommt den fertigen String mit dem Datum und nichts anderes interessiert sie.
+
+Der Gewinn ist banal, aber real: Ich kann die sechs Tests `computeStreak` ohne Internet, ohne Mocking von `fetch`, ohne irgendeinen Stub-Server ausführen. Ich gebe einen String ein, ich bekomme ein Ergebnis, Ende der Geschichte. Die gesamte Unsicherheit der Außenwelt, der tote Feed, der falsche Content-Type, DNS, landet an einem Ort, im Skill-Schritt, wo ich sie ohnehin manuell behandeln muss.
+
+## Was jetzt tatsächlich auf Slack landet
+
+Die zweite Hälfte dieser Arbeit ist nicht Code, sondern `.claude/skills/propose-topics/SKILL.md`, wo ich das genaue Format der Nachricht definiert habe. Wenn es etwas zu schreiben gibt, landet eine nummerierte Liste mit einem konkreten Aufruf zum Handeln, nicht einem trockenen einzelnen Wort:
+
+```text
+Themen für diese Woche:
+
+1. <title>
+   Winkel: <angle>
+   Warum jetzt: <why_now>
+
+Antworte 1-5 oder schreibe dein eigenes Thema, wenn keines passt.
+```
+
+Und wenn die Woche leer war, landet etwas, das Dinge beim Namen nennt, anstatt zu schweigen, zusammen mit einem Zähler, wenn die Pause länger als eine Woche dauert:
+
+```text
+Nichts in dieser Woche passt für einen eigenen Beitrag.
+
+Ich habe überprüft: Commits der letzten 7 Tage und bereits beschriebene Themen in content/posts/. Nur kleine
+Änderungen, nichts für einen eigenen Beitrag.
+
+2. Woche in Folge ohne neuen Beitrag.
+```
+
+Dieses zweite Format ist wichtiger, als es aussieht. Ein Bot, der nur dann spricht, wenn er eine gute Nachricht für dich hat, bringt dich dazu, die Stille zu ignorieren. Ein Bot, der sagt "ich habe überprüft, nichts da, und das ist bereits die zweite Woche in Folge", verwandelt die Stille in ein Signal. Das ist der gesamte Unterschied zwischen einem Ideengenerierungstool und einem Tool, das als dein Gewissen fungiert.
+
+Die Nachricht selbst landet auf `#blog-ideas` durch einen Webhook, nicht durch den Slack-Connector, weil der Connector an einem anderen Workspace sitzt und physisch nicht zu diesem Kanal gelangen kann. Ein einfacher `curl` mit JSON, das von `jq` gebaut wird, um nicht mit escaped Anführungszeichen in der Nachricht zu kämpfen, die ohnehin von einer LLM generiert wird.
+
+## Wann ein solcher Freshness-Check überhaupt keinen Sinn ergibt
+
+Ehrlich in die andere Richtung, weil es leicht ist, aus diesem Beitrag mit der Überzeugung herauszugehen, dass jeder Skill seinen eigenen Zeitzähler benötigt. Das tut er nicht. Ich hätte es anders gebaut oder gar nicht, wenn:
+
+- **der Blog mehrere Autoren hätte**, weil "X Wochen ohne Beitrag" dann nicht mehr mein persönliches Verschämen ist, sondern eine Team-Metrik, die eine ganz andere Diskussion darüber erfordert, wer sie auf Slack erhält,
+- **ich öfter als einmal pro Woche veröffentliche**, weil der Wochen-Zähler dann zu grob ist und man in Tagen zählen müsste, was die gesamte Arithmetik und die Schwellenwerte in `computeStreak` ändert,
+- **ich den `propose-topics`-Skill nicht bereits hätte**, weil die gesamte Arbeit dann ein Aufbau auf etwas wäre, das ohnehin bereits den Git-Log liest. Das Bauen eines Freshness-Checks von Grund auf, ohne diese Basis, ist viel mehr Arbeit für denselben Effekt.
+
+Keine dieser drei Bedingungen beschreibt meine Situation: Ich blogge allein, seltener als einmal pro Woche, und der Skill zur Ideengenerierung lag mir bereits im Repo. Daher diese spezifische Form der Lösung, nicht eine andere.
+
+## Was daraus wurde
+
+Der PR #7, `d33836d`, ging am Mittwochabend live. Drei Dateien: `streak.ts`, `streak.test.ts`, ein neues Nachrichtenformat in `SKILL.md`. Sechsundsechzig Zeilen wurden in `SKILL.md` hinzugefügt, weil das Beschreiben von zwei Nachrichtenformaten mit Worten mehr Platz einnimmt als das Schreiben des Codes, der sie generiert.
+
+Jetzt, wenn ich `propose-topics` starte, bekomme ich nicht mehr nur eine trockene Liste von Themen, losgelöst vom Kontext. Ich bekomme eine Liste plus einen Satz im Stil "2. Woche in Folge ohne neuen Beitrag", der wie ein Eimer kaltes Wasser wirkt. Du musst mir nicht aufs Wort glauben, dass es funktioniert, weil das genau der Mechanismus ist, der dazu geführt hat, dass dieser Beitrag überhaupt in dieser Woche entstanden ist und nicht in zwei Wochen.
+
+Und das ist die Ironie, auf die ich von dem ersten Satz an hingearbeitet habe: Ich habe ein Tool gebaut, das mich daran erinnert, zu schreiben, und der erste Text, den ich dank ihm geschrieben habe, ist die Beschreibung dieses Tools. Der Bot hat mich daran erinnert, dass ich nicht schreibe, also setzte ich mich hin und schrieb den Beitrag über das Tool, das mich daran erinnert. Das Gewissen, das du dir selbst programmiert hast, ist immer noch ein Gewissen, nur dass es jetzt Zugang zu deinem Slack hat.
+
+## FAQ
+
+**Warum gibt `weeksSinceLastPost` `null` zurück und nicht `0`, wenn etwas schiefgeht?**
+Weil null und null etwas völlig anderes bedeuten. Null bedeutet "ich kann das nicht zählen, weil der Feed mir etwas zurückgegeben hat, das ich nicht parsen kann". Zurückgeben von null in dieser Situation ist das, wofür fail-closed da ist.
+
+**Warum ist der Feed-Fetch nicht Teil von `computeStreak`?**
+Weil die Funktion dann nicht mehr testbar ist, ohne das Internet zu mocken. Die Aufteilung in reine Logik in `streak.ts` und I/O im Skill-Schritt kopiert ein Muster, das bereits im Repo zwischen `feed.ts` und `feed.json/route.ts` existiert. Sechs Tests `computeStreak` können ohne Internet ausgeführt werden.
+
+**Warum landet die Nachricht durch einen Webhook und nicht durch den Slack-Connector?**
+Weil der Connector an einem anderen Workspace angeschlossen ist und keinen Zugang zu dem Kanal `#blog-ideas` hat, auf dem ich tatsächlich arbeite. Ein Webhook ist ein einfacher öffentlicher Endpoint-URL, also erledigt `curl` mit `jq`, das JSON aufbaut, die Sache ohne irgendeine zusätzliche Autorisierung auf meiner Seite.
+
+**Was passiert, wenn es nichts zu schreiben gibt?**
+Der Skill sendet trotzdem eine Nachricht, nur eine andere: Er sagt direkt, was er überprüft hat (Commits der letzten 7 Tage, bereits beschriebene Themen) und dass nichts davon sich für einen Beitrag eignet. Wenn die Pause länger als eine Woche dauert, fügt er einen Zähler im Stil "2. Woche in Folge ohne neuen Beitrag" hinzu. Schweigen ohne Erklärung wäre schlimmer als ein ehrliches "nichts da".
+
+**Ist es nicht übertrieben, sich selbst einen Bot zu bauen, der einen daran erinnert, auf dem eigenen Blog zu schreiben?**
+Dieser Beitrag entstand, weil der Bot mich daran erinnerte, also verteidigt sich die Antwort selbst. Wenn ich mehrere Autoren hätte oder täglich veröffentlichen würde, hätte ich es anders gemacht oder gar nicht, siehe den Abschnitt darüber, wann ein Freshness-Check keinen Sinn ergibt.
+
+## Links
+
+- [Mein vorheriger Beitrag über Hooks, Skills und Subagenten in Claude Code](/blog/de/how-to-setup-claude-code-hooks-skills)
+- [Wie eine LLM meine Links in den Übersetzungen durcheinandergebracht hat](/blog/de/llm-translated-my-blog-and-broke-the-links)
+- [Ich habe eine agent-ready-Seite gebaut: llms.txt und Content-Signals](/blog/de/how-to-make-your-website-agent-ready)
+- [Mein eigener MCP-Server, durch den der Agent die Blog-Statistiken liest](/blog/de/how-to-build-mcp-server-for-analytics)
+- [Öffentlicher JSON-Feed des Blogs](https://dev.paczesny.pl/feed.json)
+- [Slack Incoming Webhooks, Dokumentation](https://api.slack.com/messaging/webhooks)

--- a/content/posts/i-made-my-blog-nag-me-on-slack/en.mdx
+++ b/content/posts/i-made-my-blog-nag-me-on-slack/en.mdx
@@ -1,0 +1,154 @@
+---
+title: I Made My Blog Remind Me on Slack When I Stop Writing
+description: propose-topics now counts weeks without a post using a fail-closed pure function, and sends topics or an honest 'nothing this week' to #blog-ideas.
+date: 2026-07-09T09:00:00.000Z
+tags: slack, automatyzacja, ideation, typescript, testy, agenci, webhook
+---
+
+## Introduction
+
+Wednesday, I check when I last published something, and instead of counting in my head "it's been a week, maybe more", I do something that's never happened before: I ask a bot I built myself. Because two days earlier, I added a feature that counts how many weeks I've been silent and reminds me on Slack before I even realize it.
+
+This is the moment when you realize you have a process for generating blog ideas, but the whole process relies on you remembering to start it. I had a `propose-topics` skill that read the git log and suggested topics. It worked well. The problem was that I had to remind myself to run it, and reminding myself about things is exactly what I'm worst at.
+
+You'll get three things from this post:
+
+1. **how `computeStreak` looks**, a pure function that counts weeks without a post, which fails closed instead of lying with zero,
+2. **why the feed fetch lives in the skill, not in a library**, and why it's not an architectural whim,
+3. **what the message looks like that now lands on #blog-ideas**, both the version with topics and the honest "nothing this week" version.
+
+## Starting Point: A Skill That Waits for You to Call It
+
+`propose-topics` already had its job covered: it read the `git log` from the last seven days, looked at what's in `content/posts/` to avoid duplicating a topic, and produced a list of 3 to 5 candidates or honestly said "nothing this week grabs a post". The problem wasn't in the logic. The problem was that I was the trigger. The skill didn't know when I last published something, so it couldn't tell me until I asked it.
+
+And I asked it when I happened to remember. Which was rare.
+
+## computeStreak: A Pure Function, Zero I/O
+
+I started the solution with the most boring possible thing: a function that calculates a date difference. All the logic sits in `src/lib/streak.ts`, without a fetch, without side effects, so it can be tested without mocking half the internet:
+
+```ts
+export function computeStreak(
+  lastPublishedIso: string | undefined,
+  options?: { now?: Date }
+): StreakResult {
+  const now = options?.now ?? new Date()
+
+  const timestamp = parsePublishedTimestamp(lastPublishedIso)
+  if (timestamp === null) {
+    // Fail closed: an unparseable or missing date is no signal, not zero weeks.
+    return { weeksSinceLastPost: null, streakNote: null }
+  }
+
+  const daysSince = (now.getTime() - timestamp) / MS_PER_DAY
+  const weeksSinceLastPost = Math.max(0, Math.floor(daysSince / DAYS_PER_WEEK))
+
+  const streakNote =
+    weeksSinceLastPost >= 1
+      ? `${weeksSinceLastPost}. week in a row without a new post`
+      : null
+
+  return { weeksSinceLastPost, streakNote }
+}
+```
+
+One decision here hurts the most from the outside, but it's the only right one: if `parsePublishedTimestamp` gets something it can't parse, the function returns `null`, not `0`. You see the difference? Zero weeks means "you're posting regularly, everything's fine". Null means "I have no idea, because the feed fell apart". Confusing these two is exactly what fail-closed is meant to avoid.
+
+I wrote this as the first test, before I even started the rest:
+
+```ts
+it("fails closed on an unparseable date, returning null rather than zero", () => {
+  const result = computeStreak("not-a-date", { now: NOW })
+
+  expect(result.weeksSinceLastPost).toBeNull()
+  expect(result.streakNote).toBeNull()
+})
+
+it("treats a missing date as no signal, returning null rather than zero", () => {
+  const result = computeStreak(undefined, { now: NOW })
+
+  expect(result.weeksSinceLastPost).toBeNull()
+  expect(result.streakNote).toBeNull()
+})
+```
+
+Six tests in total in `src/lib/streak.test.ts`, from zero weeks after a fresh post, through exactly one week of break, through a multi-week gap, to these two fail-closed cases and one checking that `now` defaults to the real clock when you don't pass it. Injectable `now` isn't a decoration, it's the only way to test "one week break" without it starting to flake after a month, because someone wrote it with a hardcoded "today" date.
+
+## Why Fetch Doesn't Sit in the Same Function
+
+I could have thrown `fetch("https://dev.paczesny.pl/feed.json")` straight into `computeStreak` and had one function for everything. I didn't do that, because the repo already has exactly the same split elsewhere: `feed.ts` holds the pure logic of building the feed, and `feed.json/route.ts` does I/O and serves it as an endpoint. `streak.ts` follows the same path, fetch stays in the skill step, and the function gets a ready string with the date and nothing else concerns it.
+
+The gain is banal but real: I can run six `computeStreak` tests without the internet, without mocking `fetch`, without any stub server. I pass a string, I get a result, end of story. All the uncertainty of the external world, a dead feed, wrong content-type, DNS, lands in one place, in the skill step, where I have to handle it manually anyway.
+
+## What Actually Lands on Slack Now
+
+The second half of this job isn't code, but `.claude/skills/propose-topics/SKILL.md`, where I defined the exact format of the message. When there's something to write about, it flies as a numbered list with a concrete call to action, not a dry single word:
+
+```text
+Topics for this week:
+
+1. <title>
+   Angle: <angle>
+   Why now: <why_now>
+
+Reply 1-5, or write your own topic if none fit.
+```
+
+And when the week was barren, it flies something that calls things by their name instead of being silent, along with a counter if the break lasts longer than a week:
+
+```text
+Nothing this week grabs a post.
+
+I checked: commits from the last 7 days and topics already described in content/posts/. Just minor
+changes, nothing for a separate post.
+
+2. week in a row without a new post.
+```
+
+This second format is more important than it looks. A bot that only speaks up when it has good news for you teaches you to ignore silence. A bot that says "I checked, there's nothing, and it's already the second week in a row" turns silence into a signal. That's the whole difference between an ideation tool and a tool that acts as your conscience.
+
+The message itself flies to `#blog-ideas` via a webhook, not through a Slack connector, because the connector is tied to a different workspace and doesn't have access to the `#blog-ideas` channel on the one I actually work on. A simple `curl` with `jq` building JSON takes care of it without any additional authorization on my part.
+
+## When Such a Freshness Check Makes No Sense
+
+Honestly, on the other hand, because it's easy to come out of this post with the conviction that every skill needs its own time counter. It doesn't. I would have built it differently or not at all if:
+
+- **the blog had multiple authors**, because then "X weeks without a post" stops being my private shame and becomes a team metric that requires a completely different conversation about who gets it on Slack,
+- **I published more often than once a week**, because then the week counter is too coarse and you'd need to count in days, which changes the whole arithmetic and thresholds in `computeStreak`,
+- **I didn't already have the `propose-topics` skill**, because all this work is a layer on top of something that already reads the git log. Building a freshness check from scratch, without that basis, is a lot more work for the same effect.
+
+None of these three conditions describes my situation: I blog alone, less often than once a week, and the skill for generating topics was already lying in my repo. Hence this specific shape of the solution, not another.
+
+## What Came Out of This
+
+PR #7, `d33836d`, went in on Wednesday evening. Three files: `streak.ts`, `streak.test.ts`, a new message format in `SKILL.md`. Sixty-four lines added in `SKILL.md` alone, because describing two message formats with words takes more space than writing the code that generates them.
+
+Now when I run `propose-topics`, I no longer get a dry list of topics detached from context. I get a list plus a sentence like "2. week in a row without a new post", which works like a bucket of cold water. You don't have to take my word for it that it works, because this is exactly the mechanism that made this post happen this week, not two weeks from now.
+
+And that's the irony I've been heading towards from the first sentence: I built a tool that reminds me to write, and the first text it reminded me to write is a description of that tool. The bot reminded me that I'm not writing, so I sat down and wrote a post about how the bot reminds me. A conscience that you've programmed yourself still is a conscience, only now it has access to your Slack.
+
+## FAQ
+
+**Why does `weeksSinceLastPost` return `null`, not `0`, when something goes wrong?**
+Because zero and null mean something completely different. Zero means "you published this week, everything's fine". Null means "I don't know how to count this, because the feed returned something I couldn't parse". Returning zero in the second situation is false reassurance, exactly what fail-closed is meant to avoid.
+
+**Why isn't the feed fetch part of `computeStreak`?**
+Because then the function stops being testable without mocking the network. The split between pure logic in `streak.ts` and I/O in the skill step copies a pattern that already exists in the repo between `feed.ts` and `feed.json/route.ts`. Six `computeStreak` tests run without the internet.
+
+**Why does the message fly through a webhook, not through a Slack connector?**
+Because the connector is tied to a different workspace and doesn't have access to the `#blog-ideas` channel on the one I actually work on. A webhook is a simple public endpoint URL, so `curl` with `jq` building JSON takes care of it without any additional authorization on my part.
+
+**What happens when there's nothing to write about?**
+The skill still sends a message, just a different one: it says what it checked (commits from the last 7 days, existing posts) and that nothing grabs a post. If the break lasts longer than a week, it appends a counter in the style "2. week in a row without a new post". Silence without explanation would be worse than honest "there's nothing".
+
+**Isn't it an overkill to build a bot to watch over your own blog?**
+This post was created because the bot reminded me to write it, so the answer probably defends itself. If I had co-authors or published daily, I would have done it differently or not at all, see the section on when a freshness check doesn't make sense.
+
+## Links
+
+- [My previous post about hooks, skills, and subagents in Claude Code](/blog/en/how-to-setup-claude-code-hooks-skills)
+- [How an LLM messed up my links in translations](/blog/en/llm-translated-my-blog-and-broke-the-links)
+- [I made my website agent-ready: llms.txt and Content-Signals](/blog/en/how-to-make-your-website-agent-ready)
+- [My own MCP server, through which the agent reads blog statistics](/blog/en/how-to-build-mcp-server-for-analytics)
+- [Public JSON feed of the blog](https://dev.paczesny.pl/feed.json)
+- [Slack Incoming Webhooks, documentation](https://api.slack.com/messaging/webhooks)

--- a/content/posts/i-made-my-blog-nag-me-on-slack/fr.mdx
+++ b/content/posts/i-made-my-blog-nag-me-on-slack/fr.mdx
@@ -1,0 +1,151 @@
+---
+title: J'ai créé un bot pour me rappeler de publier sur mon blog Slack lorsque je cesse d'écrire
+description: propose-topics compte les semaines sans publication avec une fonction fail-closed et envoie des sujets ou un "rien cette semaine" honnête sur #blog-ideas.
+date: 2026-07-09T09:00:00.000Z
+tags: slack, automatyzacja, ideation, typescript, testy, agenci, webhook
+---
+
+## Introduction
+
+Mercredi, je vérifie quand j'ai publié quelque chose pour la dernière fois, et au lieu de compter dans ma tête "c'est probablement une semaine, peut-être plus", je fais quelque chose que je n'ai jamais fait auparavant : je demande à un bot que j'ai moi-même construit. Car deux jours plus tôt, j'ai ajouté une fonctionnalité qui compte elle-même les semaines pendant lesquelles je me tais et qui me rappelle sur Slack avant même que je m'en rende compte.
+
+C'est le moment où vous réalisez que vous avez un processus pour générer des idées de blog, mais que tout ce processus repose sur le fait que vous devez vous souvenir de le lancer. J'avais une compétence `propose-topics` qui lisait le journal Git et suggérait des sujets. Cela fonctionnait bien. Mais je devais me souvenir de le lancer, et me souvenir des choses est exactement ce que je fais le moins bien.
+
+Vous obtiendrez trois choses de ce billet :
+
+1. **comment `computeStreak` est conçu**, une fonction pure qui compte les semaines sans publication, qui échoue de manière fermée au lieu de mentir avec zéro,
+2. **pourquoi la récupération du flux est dans la compétence et non dans la bibliothèque**, et pourquoi ce n'est pas une fantaisie architecturale,
+3. **comment le message qui atterrit maintenant sur #blog-ideas**, à la fois la version avec des sujets et la version sincère "rien cette semaine".
+
+## Point de départ : une compétence qui attend d'être appelée
+
+`propose-topics` avait déjà sa tâche bien en main : lire le journal Git des sept derniers jours, vérifier ce qui se trouve dans `content/posts/` pour ne pas dupliquer le sujet, et produire une liste de 3 à 5 candidats ou dire honnêtement "rien cette semaine ne se prête à un billet". Le problème n'était pas dans la logique. Le problème était que c'était moi qui déclenchais la compétence. La compétence ne savait pas quand j'avais publié quelque chose pour la dernière fois, donc elle ne pouvait pas me le dire tant que je ne la questionnais pas.
+
+Et je la questionnais quand je me souvenais de le faire. C'est-à-dire rarement.
+
+## computeStreak : une fonction pure, zéro I/O
+
+J'ai commencé par la chose la plus ennuyeuse possible : une fonction qui calcule la différence de dates. Toute la logique se trouve dans `src/lib/streak.ts`, sans récupération, sans effets secondaires, pour que cela puisse être testé sans mockup de la moitié d'Internet :
+
+```ts
+export function computeStreak(
+  lastPublishedIso: string | undefined,
+  options?: { now?: Date }
+): StreakResult {
+  const now = options?.now ?? new Date()
+
+  const timestamp = parsePublishedTimestamp(lastPublishedIso)
+  if (timestamp === null) {
+    // Échec fermé : une date non analysable ou manquante n'est pas un signal, mais pas zéro semaines non plus.
+    return { weeksSinceLastPost: null, streakNote: null }
+  }
+
+  const daysSince = (now.getTime() - timestamp) / MS_PER_DAY
+  const weeksSinceLastPost = Math.max(0, Math.floor(daysSince / DAYS_PER_WEEK))
+
+  const streakNote =
+    weeksSinceLastPost >= 1
+      ? `${weeksSinceLastPost}. semaine d'affilée sans nouveau billet`
+      : null
+
+  return { weeksSinceLastPost, streakNote }
+}
+```
+
+Une décision ici fait mal en regardant de l'extérieur, mais c'est la seule décision sensée : si `parsePublishedTimestamp` reçoit quelque chose qu'il ne peut pas analyser, la fonction retourne `null`, et non `0`. Vous voyez la différence ? Zéro semaine signifie "vous publiez régulièrement, tout va bien". Null signifie "je n'ai aucune idée, car le flux s'est effondré". Confondre ces deux choses en une seule direction, c'est un bot qui vous félicite pour votre travail acharné, alors que en réalité, il s'est lui-même cassé et n'a rien à compter. J'ai écrit cela comme premier test, avant même de lancer le reste :
+
+```ts
+it("échoue fermement sur une date non analysable, en retournant null plutôt que zéro", () => {
+  const result = computeStreak("not-a-date", { now: NOW })
+
+  expect(result.weeksSinceLastPost).toBeNull()
+  expect(result.streakNote).toBeNull()
+})
+
+it("traite une date manquante comme un signal absent, en retournant null plutôt que zéro", () => {
+  const result = computeStreak(undefined, { now: NOW })
+
+  expect(result.weeksSinceLastPost).toBeNull()
+  expect(result.streakNote).toBeNull()
+})
+```
+
+Six tests au total dans `src/lib/streak.test.ts`, allant de zéro semaine après une publication récente, en passant par une semaine exacte de pause, jusqu'à une pause de plusieurs semaines, et enfin ces deux cas d'échec fermé et un test vérifiant que `now` prend par défaut l'horloge réelle, si vous ne lui donnez rien. Un `now` injectable n'est pas un ornement, c'est la seule façon de rendre le test sur "une semaine de pause" qui ne commence pas à clignoter au bout d'un mois, parce que quelqu'un l'a écrit avec une date "aujourd'hui" en dur.
+
+## Pourquoi la récupération du flux ne se trouve pas dans la même fonction
+
+J'aurais pu mettre `fetch("https://dev.paczesny.pl/feed.json")` directement dans `computeStreak` et avoir une seule fonction pour tout. Je ne l'ai pas fait, car dans le dépôt, il existe déjà exactement la même division ailleurs : `feed.ts` contient la logique pure de construction du flux, et `feed.json/route.ts` fait l'I/O et le sert comme point de terminaison. `streak.ts` suit le même chemin, la récupération du flux reste dans l'étape de la compétence, et la fonction reçoit une chaîne de date prête à l'emploi et ne s'intéresse à rien d'autre.
+
+Le gain est banal, mais réel : je peux exécuter six tests `computeStreak` sans Internet, sans mockup de `fetch`, sans aucun stub de serveur. Je donne une chaîne, j'obtiens un résultat, fin de l'histoire. Toute l'incertitude du monde extérieur, le flux mort, le mauvais type de contenu, le DNS, atterrit dans un seul endroit, dans l'étape de la compétence, où je dois de toute façon la gérer manuellement.
+
+## Ce qui atterrit réellement sur Slack
+
+La deuxième moitié de ce travail n'est pas du code, mais `.claude/skills/propose-topics/SKILL.md`, où j'ai défini le format exact du message. Lorsqu'il y a quelque chose à écrire, un message numéroté avec un appel à l'action concret est envoyé, et non un simple mot sec :
+
+```text
+Sujets pour cette semaine :
+
+1. <title>
+   Angle : <angle>
+   Pourquoi maintenant : <why_now>
+
+Répondez 1-5, ou écrivez votre propre sujet si aucun ne convient.
+```
+
+Et lorsque la semaine a été stérile, un message qui nomme les choses par leur nom au lieu de se taire est envoyé, avec un compteur si la pause dure plus d'une semaine :
+
+```text
+Rien cette semaine ne se prête à un billet.
+
+J'ai vérifié : les commits des sept derniers jours et les sujets déjà décrits dans content/posts/. Seules des modifications mineures, rien pour un billet à part.
+
+2. semaine d'affilée sans nouveau billet.
+```
+
+Ce deuxième format est plus important qu'il n'y paraît. Un bot qui ne parle que lorsqu'il a de bonnes nouvelles vous apprend à ignorer le silence. Un bot qui dit "j'ai vérifié, il n'y a rien, et c'est déjà la deuxième semaine d'affilée sans nouveau billet" transforme le silence en signal. C'est toute la différence entre un outil de génération d'idées et un outil qui fait office de conscience.
+
+Le message lui-même atterrit sur `#blog-ideas` via un webhook, et non via un connecteur Slack, car le connecteur est connecté à un autre espace de travail et n'a pas accès au canal `#blog-ideas` sur lequel je travaille réellement. Un simple `curl` avec un JSON construit par `jq` pour ne pas se battre avec les guillemets dans le contenu, que de toute façon, une intelligence artificielle génère.
+
+## Quand un tel contrôle de fraîcheur n'a absolument aucun sens
+
+Honnêtement, dans l'autre sens, car il est facile de sortir de ce billet avec l'impression que chaque compétence nécessite son propre compteur de temps. Ce n'est pas le cas. J'aurais construit cela différemment ou pas du tout, si :
+
+- **le blog avait plusieurs auteurs**, car alors "X semaines sans billet" cesse d'être ma honte personnelle et devient une métrique d'équipe, qui nécessite une conversation complètement différente sur qui la reçoit sur Slack,
+- **je publiais plus d'une fois par semaine**, car alors le compteur de semaines est trop grossier et il faudrait compter en jours, ce qui change toute l'arithmétique et les seuils dans `computeStreak`,
+- **je n'avais pas déjà la compétence `propose-topics`**, car toute cette tâche est une surcouche sur quelque chose qui lit déjà le journal Git. Construire un contrôle de fraîcheur à partir de zéro, sans cette base, c'est beaucoup plus de travail pour le même effet.
+
+Aucune de ces trois conditions ne décrit ma situation : je blogue seul, moins d'une fois par semaine, et la compétence pour générer des sujets m'était déjà fournie. D'où cette forme spécifique de la solution, et non une autre.
+
+## Ce qui en est résulté
+
+La PR #7, `d33836d`, est entrée en vigueur mercredi soir. Trois fichiers : `streak.ts`, `streak.test.ts`, un nouveau format de message dans `SKILL.md`. Soixante-quatre lignes ajoutées dans `SKILL.md` seul, car décrire deux formats de messages avec des mots prend plus de place que d'écrire le code qui les génère.
+
+Maintenant, lorsque je lance `propose-topics`, je n'obtiens plus une liste sèche de sujets détachée du contexte. J'obtiens une liste plus une phrase comme "2. semaine d'affilée sans nouveau billet", qui agit comme un seau d'eau froide. Vous n'avez pas à me croire sur parole, car c'est exactement le mécanisme qui a fait que ce billet a été créé cette semaine, et non dans deux semaines.
+
+Et c'est l'ironie à laquelle je tendais depuis la première phrase : j'ai construit un outil qui me rappelle d'écrire, et le premier texte que j'ai écrit grâce à lui est la description de cet outil. Le bot m'a rappelé que je ne publiais pas, donc je me suis assis et j'ai écrit un billet sur le fait que le bot me rappelle. La conscience que vous vous êtes vous-même programmée est toujours une conscience, elle a simplement accès à votre Slack.
+
+## FAQ
+
+**Pourquoi `weeksSinceLastPost` retourne `null`, et non `0`, lorsque quelque chose ne va pas ?**
+Parce que zéro et null signifient quelque chose de complètement différent. Zéro signifie "vous avez publié cette semaine, tout va bien". Null signifie "je ne sais pas le calculer, car le flux m'a retourné quelque chose que je ne sais pas analyser". Retourner zéro dans cette deuxième situation, c'est un faux réconfort, exactement ce que l'échec fermé est censé éviter.
+
+**Pourquoi la récupération du flux ne fait-elle pas partie de `computeStreak` ?**
+Parce que sinon, la fonction cesse d'être testable sans mockup du réseau. La division entre la logique pure dans `streak.ts` et l'I/O dans l'étape de la compétence copie un modèle qui existe déjà dans le dépôt entre `feed.ts` et `feed.json/route.ts`. Six tests `computeStreak` s'exécutent sans Internet.
+
+**Pourquoi le message atterrit-il via un webhook, et non via un connecteur Slack ?**
+Parce que le connecteur est connecté à un autre espace de travail et n'a pas accès au canal `#blog-ideas` sur lequel je travaille réellement. Le webhook est un point de terminaison URL public, donc `curl` avec `jq` construisant le JSON fait l'affaire sans autorisation supplémentaire de ma part.
+
+**Que se passe-t-il lorsqu'il n'y a rien à écrire ?**
+La compétence envoie toujours un message, mais différent : elle dit clairement ce qu'elle a vérifié (les commits des sept derniers jours et les sujets déjà décrits dans content/posts/) et qu'il n'y a rien qui se prête à un billet. Si la pause dure plus d'une semaine, elle ajoute un compteur dans le style "2. semaine d'affilée sans nouveau billet". Le silence sans explication serait pire qu'un "il n'y a rien" honnête.
+
+**N'est-ce pas excessif de se créer un bot pour surveiller son propre blog ?**
+Ce billet a été créé parce que le bot me l'a rappelé, donc la réponse se défend d'elle-même. Si j'avais des co-auteurs ou que je publiais quotidiennement, j'aurais fait les choses différemment ou pas du tout, voir la section sur les cas où le contrôle de fraîcheur n'a pas de sens.
+
+## Liens
+
+- [Mon billet précédent sur les hooks, les compétences et les sous-agents dans Claude Code](/blog/fr/how-to-setup-claude-code-hooks-skills)
+- [Comment LLM a mélangé mes liens dans les traductions](/blog/fr/llm-translated-my-blog-and-broke-the-links)
+- [J'ai rendu mon site prêt pour les agents : llms.txt et Content-Signals](/blog/fr/how-to-make-your-website-agent-ready)
+- [Mon propre serveur MCP, que l'agent utilise pour lire les statistiques du blog](/blog/fr/how-to-build-mcp-server-for-analytics)
+- [Flux JSON public du blog](https://dev.paczesny.pl/feed.json)
+- [Webhooks entrants Slack, documentation](https://api.slack.com/messaging/webhooks)

--- a/content/posts/i-made-my-blog-nag-me-on-slack/pl.mdx
+++ b/content/posts/i-made-my-blog-nag-me-on-slack/pl.mdx
@@ -1,0 +1,152 @@
+---
+title: "Zrobiłem, żeby blog sam się upominał na Slacku, kiedy przestaję pisać"
+description: "propose-topics liczy teraz tygodnie bez wpisu czystą funkcją fail-closed i sam wysyła tematy albo szczere 'nic w tym tygodniu' na #blog-ideas."
+date: 2026-07-09T09:00:00.000Z
+tags: slack, automatyzacja, ideation, typescript, testy, agenci, webhook
+---
+
+## Wprowadzenie
+
+Środa, sprawdzam kiedy ostatnio coś opublikowałem, i zamiast liczyć w głowie "no chyba z tydzień, może więcej", robię coś, co się nigdy wcześniej nie zdarzyło: pytam o to bota, którego sam sobie zbudowałem. Bo dwa dni wcześniej dopisałem mu funkcję, która sama liczy, ile tygodni milczę, i sama się o to upomina na Slacku, zanim ja się w ogóle zorientuję.
+
+To jest ten moment, w którym docierasz, że masz proces do generowania pomysłów na bloga, tylko cały ten proces polega na tym, że Ty musisz pamiętać, żeby go odpalić. Miałem skill `propose-topics`, który czyta git log i podsuwa tematy. Działał dobrze. Tylko że ja musiałem sobie przypomnieć, żeby go uruchomić, a przypominanie sobie o rzeczach jest dokładnie tym, w czym jestem najgorszy.
+
+Dostaniesz trzy rzeczy z tego wpisu:
+
+1. **jak wygląda `computeStreak`**, czysta funkcja licząca tygodnie bez wpisu, która fail-closed'uje zamiast kłamać zerem,
+2. **czemu fetch feedu żyje w skillu, a nie w bibliotece**, i czemu to nie jest kaprys architektoniczny,
+3. **jak wygląda wiadomość, która teraz sama ląduje na #blog-ideas**, zarówno wersja z tematami jak i szczera wersja "nic w tym tygodniu".
+
+## Punkt wyjścia: skill, który czeka, aż go zawołasz
+
+`propose-topics` miał już swoją robotę ogarniętą: czyta `git log` z ostatnich siedmiu dni, patrzy co jest w `content/posts/`, żeby nie zdublować tematu, i produkuje listę 3 do 5 kandydatów albo uczciwie mówi "nic w tym tygodniu nie łapie się na wpis". Problem nie był w logice. Problem był w tym, że to ja byłem triggerem. Skill nie wiedział, kiedy ostatnio coś opublikowałem, więc nie mógł mi tego powiedzieć, dopóki go nie zapytałem.
+
+A ja pytałem go wtedy, kiedy akurat pamiętałem. Czyli rzadko.
+
+## computeStreak: czysta funkcja, zero I/O
+
+Rozwiązanie zacząłem od najnudniejszej możliwej rzeczy: funkcji, która liczy różnicę dat. Cała logika siedzi w `src/lib/streak.ts`, bez fetcha, bez efektów ubocznych, żeby dało się to testować bez mockowania połowy internetu:
+
+```ts
+export function computeStreak(
+  lastPublishedIso: string | undefined,
+  options?: { now?: Date }
+): StreakResult {
+  const now = options?.now ?? new Date()
+
+  const timestamp = parsePublishedTimestamp(lastPublishedIso)
+  if (timestamp === null) {
+    // Fail closed: an unparseable or missing date is no signal, not zero weeks.
+    return { weeksSinceLastPost: null, streakNote: null }
+  }
+
+  const daysSince = (now.getTime() - timestamp) / MS_PER_DAY
+  const weeksSinceLastPost = Math.max(0, Math.floor(daysSince / DAYS_PER_WEEK))
+
+  const streakNote =
+    weeksSinceLastPost >= 1
+      ? `${weeksSinceLastPost}. tydzień z rzędu bez nowego wpisu`
+      : null
+
+  return { weeksSinceLastPost, streakNote }
+}
+```
+
+Jedna decyzja tu boli najbardziej patrząc z zewnątrz, ale jest jedyną słuszną: jak `parsePublishedTimestamp` dostanie coś, czego nie umie sparsować, funkcja zwraca `null`, nie `0`. Widzisz różnicę? Zero tygodni znaczy "piszesz regularnie, wszystko super". Null znaczy "nie mam pojęcia, bo feed mi się posypał". Pomylenie tych dwóch w jedną stronę to bot, który cię chwali za pracowitość, kiedy tak naprawdę sam się zepsuł i nie ma z czego liczyć. Napisałem to jako pierwszy test, zanim w ogóle ruszyłem resztę:
+
+```ts
+it("fails closed on an unparseable date, returning null rather than zero", () => {
+  const result = computeStreak("not-a-date", { now: NOW })
+
+  expect(result.weeksSinceLastPost).toBeNull()
+  expect(result.streakNote).toBeNull()
+})
+
+it("treats a missing date as no signal, returning null rather than zero", () => {
+  const result = computeStreak(undefined, { now: NOW })
+
+  expect(result.weeksSinceLastPost).toBeNull()
+  expect(result.streakNote).toBeNull()
+})
+```
+
+Sześć testów w sumie w `src/lib/streak.test.ts`, licząc od zera tygodni po świeżym wpisie, przez dokładnie tydzień przerwy, przez wielotygodniową dziurę, aż po te dwa fail-closed przypadki i jeden sprawdzający, że `now` domyślnie łapie prawdziwy zegar, kiedy nic mu nie podasz. Injectable `now` to nie ozdobnik, to jedyny sposób, żeby test na "tydzień przerwy" nie zaczął migać za miesiąc, bo ktoś napisał go z twardo wbitą datą "dzisiaj".
+
+## Czemu fetch nie siedzi w tej samej funkcji
+
+Mogłem wrzucić `fetch("https://dev.paczesny.pl/feed.json")` prosto do `computeStreak` i mieć jedną funkcję do wszystkiego. Nie zrobiłem tego, bo w repo już istnieje dokładnie ten sam podział gdzie indziej: `feed.ts` trzyma czystą logikę budowania feedu, a `feed.json/route.ts` robi I/O i serwuje to jako endpoint. `streak.ts` idzie tą samą drogą, fetch zostaje w kroku skilla, funkcja dostaje gotowy string z datą i nic więcej jej nie obchodzi.
+
+Zysk jest banalny, ale realny: mogę uruchomić sześć testów `computeStreak` bez internetu, bez mockowania `fetch`, bez żadnego stub serwera. Podaję string, dostaję wynik, koniec historii. Cała niepewność świata zewnętrznego, martwy feed, zły content-type, DNS, ląduje w jednym miejscu, w kroku skilla, gdzie i tak muszę ją obsłużyć ręcznie.
+
+## Co teraz faktycznie leci na Slacka
+
+Druga połowa tej roboty to nie kod, tylko `.claude/skills/propose-topics/SKILL.md`, gdzie zdefiniowałem dokładny format wiadomości. Kiedy jest co pisać, leci numerowana lista z konkretnym wezwaniem do działania, nie suchym jednym słowem:
+
+```text
+Tematy na ten tydzień:
+
+1. <title>
+   Angle: <angle>
+   Czemu teraz: <why_now>
+
+Odpisz 1-5, albo napisz własny temat jeśli żaden nie pasuje.
+```
+
+A kiedy tydzień był jałowy, leci coś, co nazywa rzeczy po imieniu zamiast milczeć, razem z licznikiem, jeśli przerwa trwa dłużej niż tydzień:
+
+```text
+Nic w tym tygodniu nie łapie się na osobny wpis.
+
+Sprawdziłem: commity z ostatnich 7 dni i tematy już opisane w content/posts/. Same drobne
+zmiany, nic na własny wpis.
+
+2. tydzień z rzędu bez nowego wpisu.
+```
+
+Ten drugi format jest ważniejszy niż wygląda. Bot, który tylko wtedy się odzywa, kiedy ma dla ciebie dobrą wiadomość, uczy cię ignorować ciszę. Bot, który mówi "sprawdziłem, nic nie ma, i to już drugi tydzień z rzędu", zamienia ciszę w sygnał. To jest cała różnica między narzędziem do ideacji a narzędziem, które robi za sumienie.
+
+Sama wiadomość leci na `#blog-ideas` przez webhook, nie przez connector Slacka, bo connector siedzi na innym workspace i fizycznie nie dobije do tego kanału. Prosty `curl` z JSON-em zbudowanym przez `jq`, żeby nie walczyć z escapowaniem cudzysłowów w treści, którą i tak generuje LLM.
+
+## Kiedy taki freshness check WCALE nie ma sensu
+
+Uczciwie w drugą stronę, bo łatwo wyjść z tego wpisu z przekonaniem, że każdy skill wymaga własnego licznika czasu. Nie wymaga. Zbudowałbym to inaczej albo wcale, gdyby:
+
+- **blog miał wielu autorów**, bo wtedy "X tygodni bez wpisu" przestaje być moim prywatnym wstydem, a staje się metryką zespołu, która wymaga zupełnie innej rozmowy o tym, kto ją dostaje na Slacku,
+- **publikowałbym częściej niż raz na tydzień**, bo wtedy licznik tygodni jest za gruboziarnisty i trzeba by liczyć w dniach, co zmienia całą arytmetykę i progi w `computeStreak`,
+- **nie miał już gotowego skilla `propose-topics`**, bo cała ta robota to nakładka na coś, co i tak już czytało git log. Budowanie freshness checka od zera, bez tamtej podstawy, to dużo więcej roboty za ten sam efekt.
+
+Żaden z tych trzech warunków nie opisuje mojej sytuacji: bloguję sam, rzadziej niż raz w tygodniu, i skill do generowania tematów już mi leżał w repo. Stąd ten konkretny kształt rozwiązania, nie inny.
+
+## Co z tego wyszło
+
+PR #7, `d33836d`, wszedł w środę wieczorem. Trzy pliki: `streak.ts`, `streak.test.ts`, nowy format wiadomości w `SKILL.md`. Sześćdziesiąt cztery linijki dodane w samym SKILL.md, bo opisanie dwóch formatów wiadomości słowami zajmuje więcej miejsca niż napisanie kodu, który je generuje.
+
+Teraz kiedy odpalam `propose-topics`, nie dostaję już suchej listy tematów oderwanej od kontekstu. Dostaję listę plus zdanie w stylu "2. tydzień z rzędu bez nowego wpisu", które działa jak kubeł zimnej wody. Nie musisz mi wierzyć na słowo, że to działa, bo to jest dokładnie ten mechanizm, który sprawił, że ten wpis w ogóle powstał w tym tygodniu, a nie za dwa.
+
+I to jest ta ironia, do której zmierzałem od pierwszego zdania: zbudowałem narzędzie, które ma mi przypominać, żebym pisał, i pierwszym tekstem, jaki dzięki niemu napisałem, jest opis tego narzędzia. Bot upomniał mnie, że nie piszę, więc usiadłem i napisałem wpis o tym, jak bot mnie upomina. Sumienie, które sam sobie zaprogramowałeś, wciąż jest sumieniem, tylko że teraz ma dostęp do Twojego Slacka.
+
+## FAQ
+
+**Dlaczego `weeksSinceLastPost` zwraca `null`, a nie `0`, kiedy coś pójdzie nie tak?**
+Bo zero i null znaczą coś zupełnie innego. Zero znaczy "opublikowałeś w tym tygodniu, wszystko gra". Null znaczy "nie umiem tego policzyć, bo feed zwrócił coś, czego nie umiem sparsować". Zwrócenie zera w tej drugiej sytuacji to fałszywe uspokojenie, dokładnie to, czego fail-closed ma unikać.
+
+**Czemu fetch feedu nie jest częścią `computeStreak`?**
+Bo wtedy funkcja przestaje być testowalna bez mockowania sieci. Podział na czystą logikę w `streak.ts` i I/O w kroku skilla kopiuje wzorzec, który już istnieje w repo między `feed.ts` a `feed.json/route.ts`. Sześć testów `computeStreak` odpala się bez internetu.
+
+**Czemu wiadomość leci przez webhook, a nie przez Slack connector?**
+Bo connector jest podpięty pod inny workspace i nie ma dostępu do kanału `#blog-ideas` na tym, na którym faktycznie działam. Webhook to zwykły publiczny endpoint URL, więc `curl` z `jq` budującym JSON załatwia sprawę bez żadnej dodatkowej autoryzacji po mojej stronie.
+
+**Co się dzieje, kiedy nie ma o czym pisać?**
+Skill i tak wysyła wiadomość, tylko inną: mówi wprost, co sprawdził (commity z ostatnich 7 dni, istniejące posty) i że nic z tego się nie łapie na wpis. Jeśli przerwa trwa dłużej niż tydzień, dokleja licznik w stylu "2. tydzień z rzędu bez nowego wpisu". Cisza bez wyjaśnienia byłaby gorsza niż uczciwe "nic nie ma".
+
+**Czy to nie jest przesada, robić sobie bota do pilnowania własnego bloga?**
+Ten wpis powstał, bo bot mi o tym przypomniał, więc odpowiedź chyba sama się broni. Gdybym miał współautorów albo publikował codziennie, zrobiłbym to inaczej albo wcale, patrz sekcja o tym, kiedy freshness check nie ma sensu.
+
+## Linki
+
+- [Mój wcześniejszy wpis o hookach, skillach i subagentach w Claude Code](/blog/pl/how-to-setup-claude-code-hooks-skills)
+- [Jak llama pomieszała mi linki w tłumaczeniach](/blog/pl/llm-translated-my-blog-and-broke-the-links)
+- [Zrobiłem stronę agent-ready: llms.txt i Content-Signals](/blog/pl/how-to-make-your-website-agent-ready)
+- [Własny serwer MCP, przez który agent czyta statystyki bloga](/blog/pl/how-to-build-mcp-server-for-analytics)
+- [Public JSON feed bloga](https://dev.paczesny.pl/feed.json)
+- [Slack Incoming Webhooks, dokumentacja](https://api.slack.com/messaging/webhooks)


### PR DESCRIPTION
## tl;dr

New post: propose-topics now reads the live `/feed.json`, computes weeks-since-last-post with a pure, fail-closed function (`src/lib/streak.ts`), and sends either a numbered topic list or an honest "nothing this week" straight to `#blog-ideas` via webhook (PR #7, `d33836d`). This post is the write-up of that feature, in `pl` (canonical) with `en`/`de`/`fr` translations.

## DoD checklist

- **DoD-1 Em dashes:** pass, zero found in any of the 4 files.
- **DoD-2 Completeness:** pass, `pl`, `en`, `de`, `fr` all present.
- **DoD-3 No truncation:** pass, header counts 9/9/9/9 matching `pl` exactly in order and sequence; word ratios 112%-125% of `pl`.
- **DoD-4 Canonical slugs:** pass, all 4 internal links per language point to real `content/posts/` directories (`how-to-setup-claude-code-hooks-skills`, `llm-translated-my-blog-and-broke-the-links`, `how-to-make-your-website-agent-ready`, `how-to-build-mcp-server-for-analytics`). `fix:post-integrity` run per language, "no fixes needed" on the final pass.
- **DoD-5 Tags:** pass, identical across all 4 languages: `slack, automatyzacja, ideation, typescript, testy, agenci, webhook`.
- **DoD-6 OG:** pass, no `coverImage` key in any language (dynamic OG). Tags don't match any themed bucket in `src/app/og/post/route.tsx`'s `THEMES` array, so it correctly resolves to `DEFAULT_THEME` (generic git/deploy scene). `og:image` returned 200 for all 4 languages in the in-session render check.
- **DoD-7 Renders:** pass, `scripts/verify-post-render.sh` passed: all 4 pages plus the OG route returned 200 after a full production build (`bun run build` + `bun run start`).
- **DoD-8 Frontmatter:** pass, all 4 `description`s at or under 160 chars (`pl` 147, `en` 147, `de` 151, `fr` 155), valid ISO date `2026-07-09T09:00:00.000Z` on all 4, well-formed `tags`.
- **F5 Stray markup / secrets:** pass, none found, all files end cleanly.
- **Unit tests:** pass, `bun run test` → 15/15 (`streak.test.ts`, `post-integrity.test.ts`, `related-posts.test.ts`).

## Internal links added

Each language's `## FAQ`/`## Linki`/`## Links`/`## Liens` section carries the same 4 cross-links (target slug shown once, path localized per language):

- `/blog/<lang>/how-to-setup-claude-code-hooks-skills`
- `/blog/<lang>/llm-translated-my-blog-and-broke-the-links`
- `/blog/<lang>/how-to-make-your-website-agent-ready`
- `/blog/<lang>/how-to-build-mcp-server-for-analytics`

## Verification evidence

- `bun run build` completed clean, 115 static pages generated, no type or build errors.
- `scripts/verify-post-render.sh i-made-my-blog-nag-me-on-slack` output: all 4 `/blog/<lang>/i-made-my-blog-nag-me-on-slack` pages and all 4 `/og/post?...&lang=<lang>` calls returned `200`.
- `bun run fix:post-integrity --slug i-made-my-blog-nag-me-on-slack --lang <en|de|fr>` run after every content change; final pass on all three: "no fixes needed".
- `bun run test`: 15/15 passing.

### Issues hit and fixed during production (for reviewer awareness)

1. **Translator frontmatter corruption (new, not covered by existing F1-F6 failure modes):** Groq's `llama-3.3-70b-versatile` appended a stray invented YAML tags list plus a fabricated/empty `coverImage` key after the real `tags:` line in all three translations. `fix:post-integrity` doesn't check for this shape of corruption, so it was fixed by hand in each file, restoring the single canonical `tags:` line with no `coverImage`.
2. **EN translation dropped the FAQ section on the first pass.** Caught by `verify-post`'s DoD-3 section-header-count check (8 headers vs 9 in `pl`), which is exactly the case that check exists for. Re-ran the translation; the second pass included FAQ but placed it after Links, so it was manually reordered to FAQ-before-Links to match the `pl.mdx` structure.
3. **All 4 frontmatter descriptions, including the canonical `pl`, initially exceeded the 160-char DoD-8 limit.** Trimmed all 4 by hand while keeping the meaning intact.

## OG image preview (per language)

- pl: ``https://dev.paczesny.pl/og/post?title=Zrobi%C5%82em%2C+%C5%BCeby+blog+sam+si%C4%99+upomina%C5%82+na+Slacku%2C+kiedy+przestaj%C4%99+pisa%C4%87&lang=pl&tags=slack%2C+automatyzacja%2C+ideation%2C+typescript%2C+testy%2C+agenci%2C+webhook``
- en: ``https://dev.paczesny.pl/og/post?title=I+Made+My+Blog+Remind+Me+on+Slack+When+I+Stop+Writing&lang=en&tags=slack%2C+automatyzacja%2C+ideation%2C+typescript%2C+testy%2C+agenci%2C+webhook``
- de: ``https://dev.paczesny.pl/og/post?title=Ich+habe+einen+Bot+gebaut%2C+der+mich+auf+Slack+erinnert%2C+wenn+ich+aufh%C3%B6re+zu+schreiben&lang=de&tags=slack%2C+automatyzacja%2C+ideation%2C+typescript%2C+testy%2C+agenci%2C+webhook``
- fr: ``https://dev.paczesny.pl/og/post?title=J%27ai+cr%C3%A9%C3%A9+un+bot+pour+me+rappeler+de+publier+sur+mon+blog+Slack+lorsque+je+cesse+d%27%C3%A9crire&lang=fr&tags=slack%2C+automatyzacja%2C+ideation%2C+typescript%2C+testy%2C+agenci%2C+webhook``

These OG URLs point at the live `dev.paczesny.pl` domain, so they won't resolve to this post until the branch is deployed. The equivalent local URLs (`http://localhost:3000/og/post?...`) all returned 200 during `scripts/verify-post-render.sh`, see DoD-6/DoD-7 above.

---

Never merged, never pushed to `dev`/`prod` directly. This PR targets `dev` and stops there for human review.


---
_Generated by [Claude Code](https://claude.ai/code/session_0183mQoTbzicMR3BdU83FcnS)_