### PR TITLE
post: Zbudowałem sobie redakcyjny pipeline z pięciu skilli Claude Code

### DIFF
--- a/content/posts/five-claude-code-skills-blog-pipeline/de.mdx
+++ b/content/posts/five-claude-code-skills-blog-pipeline/de.mdx
@@ -1,0 +1,116 @@
+---
+title: Ich habe mir eine redaktionelle Pipeline mit fünf Claude-Code-Skills aufgebaut
+description: Fünf Claude-Code-Skills in einer Kette statt eines großen Prompts fürs Bloggen. Plus ein deterministischer Fixer, weil Prompts bei Slugs lügen.
+date: 2026-07-09T12:00:00.000Z
+tags: claude-code, ai, agenty, skille, automatyzacja, blog, redakcja, workflow
+---
+
+## Einleitung
+
+Im vorherigen Beitrag schrieb ich einen Satz, der jetzt wie ein Scherz klingt: "Damit schließe ich die Serie über das Bearbeiten von Blog-Beiträgen und Agenten ab, nächstes Mal kehre ich zu normalen Anleitungen zurück". Das war vor drei Tagen. Heute sitze ich und schreibe einen weiteren Beitrag über das Bearbeiten von Blog-Beiträgen und Agenten, und zwar genau über das, was ich beschreibe. Dazu komme ich später zurück, denn das ist der ganze Punkt dieses Textes, aber erst einmal der Grund, warum ich mein Versprechen gebrochen habe.
+
+Ich hatte genug von der manuellen Erstellung von Beiträgen. Nicht des Schreibens selbst, das gefällt mir, sondern all der Arbeit drumherum: Übersetzen in drei Sprachen, Überprüfen, ob die Links in den Übersetzungen auf die richtigen Slugs verweisen, Überprüfen, ob die `tags` nicht unterwegs verloren gegangen sind, Erstellen der Seite und Klicken auf vier Versionen eines Beitrags, um zu überprüfen, ob sie sich überhaupt rendern. Jedes Mal machte ich das manuell und jedes Mal entging mir etwas. Also verbrachte ich zwei Tage damit, etwas zu schreiben, das Beiträge für mich schreiben soll. Ironisch, von Anfang an, aber ich werde es noch schlimmer machen.
+
+Sie erhalten drei Dinge:
+
+1. **Wie die fünf Skills** aussehen, die in einer Kette zusammengesetzt sind, mit echten Zeilennummern aus diesem Commit,
+2. **Warum der Prompt allein nicht ausreichte** und ich deterministischen Code hinzufügen musste, um das zu korrigieren, was der Model lügt,
+3. **Wie dieser spezifische Beitrag entstand**, denn das ist der beste Beweis dafür, ob die Pipeline funktioniert oder nur schön im README aussieht.
+
+## Was ich genau verknüpft habe
+
+Der Commit `d10b1b1` (#6, gestern) fügte dem Repository fünf Dateien `.claude/skills/*/SKILL.md`, zwei Referenzdokumente unter `_shared/`, ein TypeScript-Modul mit Tests und ein Bash-Skript zum Überprüfen des Renderings hinzu. In Zahlen:
+
+```
+.claude/skills/_shared/definition-of-done.md |  27 ++
+.claude/skills/_shared/failure-modes.md      |  65 ++
+.claude/skills/draft-post-pl/SKILL.md        | 127 ++
+.claude/skills/open-post-pr/SKILL.md         |  66 ++
+.claude/skills/propose-topics/SKILL.md       |  72 ++
+.claude/skills/translate-post/SKILL.md       |  64 ++
+.claude/skills/verify-post/SKILL.md          |  94 ++
+scripts/fix-integrity.ts                     | 126 ++
+scripts/verify-post-render.sh                | 110 ++
+src/lib/post-integrity.test.ts               | 185 ++
+src/lib/post-integrity.ts                    | 228 ++
+```
+
+Fünf Skills sind fünf separate Schritte, jeder mit einem klaren Eingang und Ausgang, und nicht ein einziger großer Prompt wie "Schreibe mir einen Blog-Beitrag und alles drumherum":
+
+1. **propose-topics.** Liest `git log` und Frontmatter von bestehenden Beiträgen und schlägt entweder 3 bis 5 Themen vor, die in der realen Aktivität des Repositorys verankert sind, oder sagt ehrlich, dass es diese Woche nichts zu schreiben gibt. Dieser Beitrag ist genau aus dieser Quelle entstanden, als erste Position in der Liste.
+2. **draft-post-pl.** Schreibt `pl.mdx` in meiner Stimme, indem es den neuesten veröffentlichten Beitrag nachahmt, mit einem obligatorischen FAQ, einem Link-Bereich und einem Gegenargument, wenn das Thema eine Entscheidung beinhaltet.
+3. **translate-post.** Ruft den bestehenden `bun run translate:post` (Groq, `llama-3.3-70b-versatile`) auf und startet sofort den Fixer für die Integrität auf der frisch erstellten Datei.
+4. **verify-post.** Fährt durch neun Tore des Definition of Done und blockiert den PR, wenn eines davon nicht bestanden wird.
+5. **open-post-pr.** Erstellt einen Branch `claude/post-<slug>`, committet logische Teile und öffnet einen PR zum `dev`. Es merget nie.
+
+Jeder Skill verlinkt zu zwei gemeinsamen Dokumenten, anstatt dieselbe Liste fünf Mal zu wiederholen: `definition-of-done.md` mit neun Toren DoD-1 bis DoD-9 und `failure-modes.md` mit sechs bekannten Ausfallmodi, F1 bis F6. Das ist keine Dekoration, sondern eine konkrete Entscheidung: Wenn sich etwas einmal verschiebt, landet die Korrektur an einem Ort und nicht in fünf separaten Dateien, die man synchronisieren muss.
+
+## Warum der Prompt allein nicht ausreichte
+
+Hier liegt der Kern, und hier half die vorherige Nacht der Forschung, die Kosten eines Frameworks zu rechtfertigen, denn ich hatte eine klare Vorstellung davon, wie ich es berechnen konnte, anstatt einfach die Hand zu heben. Zwei Ausfallmodi aus `failure-modes.md` sind durch Code und nicht durch den Prompt geschlossen, da der Prompt regelmäßig lügt:
+
+**F3, Übersetzung von Slugs.** Der Model übersetzte Wörter innerhalb von Slugs, weil sie wie Text zum Übersetzen aussehen, aber tatsächlich Identifikatoren sind. Ein bestimmtes Beispiel aus der Geschichte dieses Repositorys: `/blog/de/proxmox-czesc-druga` änderte sich in `/blog/de/proxmox-teil-zwei`, was zu einem sauberen 404 führte. Ich sagte dem Prompt, das nicht zu tun. Es half nicht konsequent.
+
+**F6, Großbuchstaben in Frontmatter, entdeckt gestern während des vollständigen Retests der Kette.** Groq gibt manchmal einen Fragment des Prompts mit einem referenziellen Block `TITLE:`, `DESCRIPTION:`, `DATE:` als gültige Ausgangsschlüssel zurück. Da `parseFrontmatter` in `src/lib/blog.ts` case-sensitiv ist, wird `metadata.title` zu `undefined`, und `src/lib/related-posts.ts` ruft `tokenize(metadata.title)` ohne Sicherheit während des Prerenderings auf. Effekt: `undefined.toLowerCase()` wirft `bun run build` für die gesamte Seite aus, nicht nur für einen Beitrag. Ein schlechtes Übersetzen konnte den gesamten Deploy blockieren.
+
+Also schrieb ich `src/lib/post-integrity.ts`, ein reiner Modul ohne Zugriff auf die Festplatte, drei Funktionen hintereinander:
+
+```ts
+export function fixPostIntegrity(
+  canonicalSlug: string,
+  translatedContent: string,
+  options?: PostIntegrityOptions
+): PostIntegrityFixResult {
+  parseFrontmatter(translatedContent) // wirft bei fehlendem Frontmatter
+
+  const slugResult = rewriteInternalSlugLinks(translatedContent, canonicalSlug, knownSlugs)
+  const caseResult = normalizeFrontmatterKeyCasing(slugResult.content)
+  const tagResult = reinsertCanonicalTags(caseResult.content, canonicalTags)
+
+  return { changed: fixes.length > 0, fixes, content: tagResult.content }
+}
+```
+
+`rewriteInternalSlugLinks` überschreibt jeden Link `](/blog/<lang>/<slug>)`, dessen Slug kein bekannter Katalog ist, zurück auf den kanonischen. `normalizeFrontmatterKeyCasing` reduziert `TITLE:` auf `title:`, indem es nur den Schlüsselnamen berührt, der Wert bleibt byte-für-byte gleich. `reinsertCanonicalTags` fügt entweder hinzu oder ersetzt die Zeile `tags`, wenn sie fehlt oder sich mit den anderen Sprachen vermischt. Die Reihenfolge in der Mitte ist wichtig: Die Normalisierung der Groß- und Kleinschreibung geht vor der Verarbeitung von Tags, da `TAGS:` mit verrückter Groß- und Kleinschreibung an der Überprüfung von Tags vorbeifliegen würde. Dazu kommen neun Tests in `post-integrity.test.ts`, sodass diese drei Funktionen eine reale Abdeckung haben und nicht nur mein Wort.
+
+Das ist der Unterschied zwischen "Ich sagte dem Model, dass es das nicht tun soll" und "Es ist physisch nicht möglich, es zum PR zu senden". Prompts sind etwa so zuverlässig wie Menschen nach dem dritten Kaffee: Sie funktionieren, solange sie funktionieren, und wenn sie nicht funktionieren, fallen sie still um.
+
+## Wenn der Prompt dennoch ausreicht
+
+Ehrlich gesagt, in die andere Richtung, denn fünf Skills bedeuten nicht, dass alles in Code umgesetzt werden muss. `propose-topics` und `draft-post-pl` bleiben reine Prompts, und das ist eine bewusste Entscheidung, kein Faulheit. Die Beurteilung, ob ein Commit aus der letzten Woche "einen eigenen Beitrag wert" ist oder ob ein Satz wie ich klingt und nicht wie generierter Text, sind Aufgaben, die nicht in einem Regex abgeschlossen werden können. Deterministischer Code erhält nur zwei Dinge, die eine einzige korrekte Antwort haben, die programmgesteuert überprüft werden kann: Ob der Slug als Katalog existiert und ob die Zeile `tags` in allen vier Sprachen identisch ist. Alles, was Urteilsvermögen erfordert, bleibt ein Prompt mit einer harten Schranke am Ende, die es überprüft. Deterministischer Code, wo es eine einzige korrekte Antwort gibt, Prompt, wo es um Beurteilung und nicht um Zählen geht, und keines von beiden gibt vor, das andere zu sein.
+
+## Wie dieser Beitrag wirklich entstand
+
+Und jetzt die ironische Krönung, die ich am Anfang versprochen habe. `propose-topics` überprüfte den Git-Log der letzten Tage, sah den Commit `d10b1b1` und schlug ihn mir als erste Position in der Liste der Themen vor, mit einer konkreten Begründung: Fünf neue Skills plus deterministischer Fixer waren am Vortag ins Repository gelangt. Ich antwortete "1". `draft-post-pl` las den neuesten veröffentlichten Beitrag, um den Rhythmus zu erfassen, zog die echten Zeilennummern und den echten Code aus demselben Commit und schrieb das, was Sie jetzt lesen. Dieselbe Pipeline, über die Sie gerade gelesen haben, produzierte den Text, den Sie über sie lesen. Es ist keine große rekursive Finte, sondern einfach die natürliche Folge davon, dass ich ein Werkzeug aufgebaut und es sofort verwendet habe, aber ich gebe zu, dass es mir ein bisschen lächerlich vorkam, als es mir während des Schreibens bewusst wurde.
+
+## FAQ
+
+**Warum fünf separate Skills und nicht ein einziger großer Prompt für den gesamten Prozess?**
+Weil jeder Schritt ein anderes Eingang, ein anderes Ausgang und eine andere Art der Überprüfung hat. Ein einziger großer Prompt kann sich nicht in der Mitte selbst stoppen, wenn die Übersetzung einen Abschnitt abbricht oder einen Tag verliert. Fünf separate Schritte mit einer harten Schranke dazwischen können das.
+
+**Erzeugen diese Skills automatisch etwas für die Produktion?**
+Nein. `open-post-pr` endet mit dem Öffnen eines PR zum `dev` und merget nie oder pushet direkt zum `dev` oder `prod`. Die Veröffentlichung ist immer eine manuelle Aktion, ich lese den PR und merge ihn selbst.
+
+**Was genau macht der deterministische Fixer, was der Prompt nicht zuverlässig machte?**
+Er überschreibt übersetzte Slugs zurück auf die kanonischen (F3), normalisiert die Groß- und Kleinschreibung von Frontmatter-Schlüsseln wie `TITLE:` auf `title:` (F6) und fügt die fehlende Zeile `tags` wieder ein (F4). Alles in `src/lib/post-integrity.ts`, kein weiterer Prompt.
+
+**Was passiert, wenn Groq den täglichen Token-Limit während der Übersetzung erreicht?**
+`translate-post` fängt diesen spezifischen Fehler ab und übersetzt die verbleibenden Sprachen mit dem Modell des Agents, der gerade die Sitzung leitet, immer noch mit denselben Toren DoD-4 und DoD-5. Am Ende erhalte ich einen Bericht, welche Sprachen durch Groq und welche durch diesen Backup-Weg gegangen sind.
+
+**Wie überprüfe ich, dass alle vier Versionen des Beitrags überhaupt gerendert werden?**
+`scripts/verify-post-render.sh` erstellt einen Build in derselben Sitzung, startet einen lokalen Server und curlt alle vier Seiten plus die URL des OG-Bildes, um den echten Statuscode 200 zu überprüfen, nicht nur den Fehler bei der Erstellung.
+
+## Zusammenfassung
+
+Ich habe mit fünf Dateien Skills, einem TypeScript-Modul mit neun Tests und einem Beitrag abgeschlossen, der sich selbst beweist. Nächstes Mal, wenn etwas in dieser Kette auseinanderfällt, werde ich genau wissen, wo: Entweder in einer der beiden Schranken, die der Code repariert, oder in einer der sieben, die hart fehlschlagen und auf mich warten.
+
+Und ehrlich gesagt: Ich habe mein Versprechen gebrochen, zu normalen Anleitungen über Self-Hosting zurückzukehren, um einen Beitrag über das System zu schreiben, das mir das Brechen dieses Versprechens vorschlug, es in meinem Stil schrieb und es selbst überprüfen würde, wenn es nicht gerade auf meinen manuellen Merge wartet. Der einzige Unterschied zwischen mir vor drei Tagen und mir jetzt ist, dass ich jetzt ein Werkzeug habe, das zumindest darauf achtet, dass die Links nicht auseinanderfallen. Self-Hosting kehrt nächstes Mal zurück. Vielleicht, es sei denn, etwas fügt sich wieder selbst hinzu.
+
+## Links
+
+- [Vorheriger Beitrag, in dem ich das Ende der Serie über Blog und Agenten versprach](/blog/de/why-i-didnt-rewrite-my-blog-to-a-new-framework)
+- [Beitrag über Hooks und Skills in Claude Code, der Ausgangspunkt für diese Pipeline](/blog/de/how-to-setup-claude-code-hooks-skills)
+- [Wie LLaMA meine Blog-Slugs durcheinandergebracht hat, die eigentliche Ursache für F3](/blog/de/llm-translated-my-blog-and-broke-the-links)
+- [Mein eigener MCP-Server, mit dem ich den Verkehr auf meinem Blog überprüfe](/blog/de/how-to-build-mcp-server-for-analytics)
+- [Claude Code, Dokumentation der Skills](https://docs.claude.com/en/docs/claude-code)
+- [Groq, Anbieter des Übersetzungsmodells](https://groq.com)

--- a/content/posts/five-claude-code-skills-blog-pipeline/en.mdx
+++ b/content/posts/five-claude-code-skills-blog-pipeline/en.mdx
@@ -1,0 +1,116 @@
+---
+title: I Built a Five-Skill Editorial Pipeline with Claude Code
+description: Five Claude Code skills chained together instead of one large prompt for writing a blog post. Plus a deterministic fixer, because prompts lie about slugs.
+date: 2026-07-09T12:00:00.000Z
+tags: claude-code, ai, agenty, skille, automatyzacja, blog, redakcja, workflow
+---
+
+## Introduction
+
+In my previous post, I wrote a sentence that now sounds like a joke: "I'm wrapping up the series on blogging and agents, and next time I'll return to normal how-to posts." That was three days ago. Today, I'm sitting here writing another post about blogging and agents, and this time, the post itself was partially created by what I'm writing about. I'll get back to that later, but first, let's talk about why I broke my promise.
+
+I was tired of manually writing posts. Not the writing itself, which I enjoy, but all the surrounding tasks: translating into three languages, making sure links in translations pointed to the correct slugs, checking if `tags` didn't disappear along the way, building the site, and clicking through four versions of the same post to see if they rendered correctly. Each time, I did it manually, and each time, something slipped through. So, instead of writing another post, I spent two days writing something that would write posts for me. It's ironic from the start, but it gets worse.
+
+You'll get three things:
+
+1. **How the five skills look** chained together, with real line numbers from this commit,
+2. **Why a single prompt wasn't enough** and I had to add deterministic code to fix what the model lies about,
+3. **How this particular post was created**, because that's the best proof of whether the pipeline works or just looks good in the README.
+
+## What I Actually Linked
+
+Commit `d10b1b1` (#6, yesterday) added five files `.claude/skills/*/SKILL.md`, two reference documents under `_shared/`, one TypeScript module with tests, and a bash script to check rendering. In numbers:
+
+```
+.claude/skills/_shared/definition-of-done.md |  27 ++
+.claude/skills/_shared/failure-modes.md      |  65 ++
+.claude/skills/draft-post-pl/SKILL.md        | 127 ++
+.claude/skills/open-post-pr/SKILL.md         |  66 ++
+.claude/skills/propose-topics/SKILL.md       |  72 ++
+.claude/skills/translate-post/SKILL.md       |  64 ++
+.claude/skills/verify-post/SKILL.md          |  94 ++
+scripts/fix-integrity.ts                     | 126 ++
+scripts/verify-post-render.sh                | 110 ++
+src/lib/post-integrity.test.ts               | 185 ++
+src/lib/post-integrity.ts                    | 228 ++
+```
+
+The five skills are five separate steps, each with a clearly described input and output, not one large prompt like "write me a blog post and everything around it":
+
+1. **propose-topics.** Reads `git log` and frontmatter of existing posts, and either proposes 3 to 5 topics anchored in real repository activity or honestly says there's nothing to write about this week. This post came from here, as the first item on the list.
+2. **draft-post-pl.** Writes `pl.mdx` in my voice, imitating the latest published post, with a mandatory FAQ, Links section, and counterargument if the topic involves a decision.
+3. **translate-post.** Calls an existing `bun run translate:post` (Groq, `llama-3.3-70b-versatile`), then immediately runs a fixer on the freshly created file.
+4. **verify-post.** Goes through nine Definition of Done gates and blocks the PR if any of them fail.
+5. **open-post-pr.** Creates a branch `claude/post-<slug>`, commits logical pieces, and opens a PR to `dev`. It never merges.
+
+Each skill links to two common documents instead of repeating the same list five times: `definition-of-done.md` with nine DoD gates and `failure-modes.md` with six known failure modes. This isn't just for show; it's a deliberate decision: if something breaks, the fix goes to one place, not five separate files that need to be synchronized.
+
+## Why a Single Prompt Wasn't Enough
+
+This is the core issue, and this is where last night's research, at the cost of a week of rewriting the framework, suddenly became useful because I had a clear head to calculate instead of waving my hand again. Two failure modes from `failure-modes.md` are closed by code, not a prompt, because the prompt regularly lied:
+
+**F3, translating slugs.** The model translated words inside slugs, because they look like text to translate, but they're identifiers. A specific example from this repository's history: `/blog/de/proxmox-czesc-druga` changed to `/blog/de/proxmox-teil-zwei`, resulting in a clean 404. I told the prompt not to do this. It didn't help consistently.
+
+**F6, capital letters in frontmatter, detected yesterday during a full retest of the chain.** Groq sometimes reflects a prompt fragment with a reference block `TITLE:`, `DESCRIPTION:`, `DATE:` as actual output keys. Since `parseFrontmatter` in `src/lib/blog.ts` is case-sensitive, `metadata.title` becomes `undefined`, and `src/lib/related-posts.ts` calls `tokenize(metadata.title)` without protection during prerender. The effect: `undefined.toLowerCase()` crashes `bun run build` for the entire site, not just one post. One bad translation could block the entire deploy.
+
+So, I wrote `src/lib/post-integrity.ts`, a pure module without disk access, three functions one after another:
+
+```ts
+export function fixPostIntegrity(
+  canonicalSlug: string,
+  translatedContent: string,
+  options?: PostIntegrityOptions
+): PostIntegrityFixResult {
+  parseFrontmatter(translatedContent) // throws if frontmatter is missing
+
+  const slugResult = rewriteInternalSlugLinks(translatedContent, canonicalSlug, knownSlugs)
+  const caseResult = normalizeFrontmatterKeyCasing(slugResult.content)
+  const tagResult = reinsertCanonicalTags(caseResult.content, canonicalTags)
+
+  return { changed: fixes.length > 0, fixes, content: tagResult.content }
+}
+```
+
+`rewriteInternalSlugLinks` rewrites every link `](/blog/<lang>/<slug>)` whose slug isn't a known directory back to the canonical one. `normalizeFrontmatterKeyCasing` brings `TITLE:` down to `title:`, touching only the key name, leaving the value byte-for-byte the same. `reinsertCanonicalTags` appends or replaces the `tags` line if it disappeared or got messed up with other languages. The order inside matters: case normalization goes before tag handling, or `TAGS:` with messed-up casing would slip past tag checking. Plus, nine tests in `post-integrity.test.ts`, so these three functions have real coverage, not just my word.
+
+This is the difference between "I told the model not to do this" and "it physically can't be sent to PR". Prompts are as reliable as people after their third cup of coffee: they work until they don't, and then they crash quietly.
+
+## When a Single Prompt Is Enough
+
+Honestly, on the other side, because five skills don't mean everything has to be code. `propose-topics` and `draft-post-pl` remain pure prompts, and that's a deliberate decision, not laziness. Evaluating whether a commit from the last week is "worth a separate post" or if a sentence sounds like me, not generated text, are tasks that can't be closed in a regex. Deterministic code gets only two things that have one correct answer, programmatically verifiable: whether a slug exists as a directory and whether the `tags` line is identical in four languages. Everything that requires judgment stays a prompt with a hard gate at the end that verifies it. Deterministic code where there's one correct answer, prompt where evaluation, not counting, is needed, and neither pretends to be the other.
+
+## How This Post Really Came to Be
+
+And now, the ironic cherry on top that I promised at the beginning. `propose-topics` looked through `git log` from the last few days, saw commit `d10b1b1`, and proposed it to me as the first item on the list of topics, with a specific justification: five new skills plus a deterministic fixer had been added to the repository the day before. I replied "1". `draft-post-pl` read the latest published post to catch the rhythm, pulled real line numbers and real code from the same commit, and wrote what you're reading now. The same pipeline that you just read about produced the text that you're reading about it. It's not some grand recursive trick; it's just the natural effect of building a tool and using it immediately. However, I admit that when it hit me while writing, it made me a bit amused.
+
+## FAQ
+
+**Why five separate skills, not one large prompt for the whole process?**
+Because each step has a different input, a different output, and a different way of verification. One large prompt can't stop itself in the middle when translation breaks a section or loses a tag. Five separate steps with a hard gate between them can.
+
+**Does this pipeline generate anything automatically for production?**
+No. `open-post-pr` ends with opening a PR to `dev` and never merges or pushes to `dev` or `prod` directly. Publication is always a manual move; I read the PR and merge it myself.
+
+**What exactly does the deterministic fixer do that the prompt didn't do reliably?**
+It rewrites translated slugs back to canonical ones (F3), normalizes the casing of frontmatter keys like `TITLE:` to `title:` (F6), and reappends the missing `tags` line (F4). All of this is code in `src/lib/post-integrity.ts`, not another instruction in the prompt.
+
+**What happens if Groq exhausts its daily token limit during translation?**
+`translate-post` catches this specific error and, instead of waiting hours, translates the remaining languages with the model of the agent that's currently leading the session, still keeping the same DoD-4 and DoD-5 gates. At the end, I get a report on which languages went through Groq and which through this backup route.
+
+**How do you check that all four versions of the post actually render?**
+`scripts/verify-post-render.sh` does a build in the same session, starts a local server, and curls all four pages plus the OG image URL, checking for a real 200 status code, not just the absence of a build error.
+
+## Summary
+
+I finished with five skill files, one TypeScript module with nine tests, and one post that proves itself. Next time something breaks in this chain, I'll know exactly where: either in one of the two gates that code fixes or in one of the seven that hard-fail and wait for me.
+
+And honestly: I promised three days ago that I'd return to normal how-to posts about self-hosting. I broke that promise to write a post about a system that proposed breaking it, wrote it in my style, and would have verified it if it weren't waiting for my manual merge. The only difference between me three days ago and me now is that now I have a tool that at least ensures links don't break. Self-hosting returns next time. Unless something writes itself again.
+
+## Links
+
+- [Previous post, where I promised the end of the series on blogging and agents](/blog/en/why-i-didnt-rewrite-my-blog-to-a-new-framework)
+- [Post about hooks and skills in Claude Code, the starting point for this pipeline](/blog/en/how-to-setup-claude-code-hooks-skills)
+- [How LLaMA messed up my blog's slugs in translations, the root cause of F3](/blog/en/llm-translated-my-blog-and-broke-the-links)
+- [My own MCP server, through which I check traffic on the blog](/blog/en/how-to-build-mcp-server-for-analytics)
+- [Claude Code, skill documentation](https://docs.claude.com/en/docs/claude-code)
+- [Groq, provider of the translation model](https://groq.com)

--- a/content/posts/five-claude-code-skills-blog-pipeline/fr.mdx
+++ b/content/posts/five-claude-code-skills-blog-pipeline/fr.mdx
@@ -1,0 +1,116 @@
+---
+title: J'ai construit un pipeline éditorial avec cinq compétences Claude Code
+description: Cinq compétences Claude Code enchaînées au lieu d'un gros prompt pour écrire un article. Plus un correctif déterministe, les prompts mentent sur les slugs.
+date: 2026-07-09T12:00:00.000Z
+tags: claude-code, ai, agenty, skille, automatyzacja, blog, redakcja, workflow
+---
+
+## Introduction
+
+Dans mon dernier article, j'ai écrit une phrase qui ressemble maintenant à une plaisanterie : "je clôture ainsi la série sur le blog et les agents, la prochaine fois, je reviens aux tutoriels classiques". C'était il y a trois jours. Aujourd'hui, j'écrit un autre article sur le blog et les agents, mais cette fois, l'article lui-même a été créé en partie grâce à ce dont je parle. Je reviendrai sur cela plus tard, car c'est le point central de cet article, mais tout d'abord, la raison pour laquelle j'ai rompu ma promesse.
+
+J'en avais marre d'écrire des articles à la main. Non pas de l'écriture elle-même, que j'aime, mais de tout ce qui l'entoure : traduire en trois langues, vérifier que les liens dans les traductions pointent vers les slug réels, vérifier que les `tags` n'ont pas disparu en route, construire la page et cliquer sur les quatre versions d'un article pour vérifier s'ils se rendent bien. Chaque fois, je le faisais à la main et chaque fois, quelque chose m'échappait. Alors, au lieu d'écrire un autre article, j'ai passé deux jours à écrire quelque chose qui allait écrire les articles à ma place. Ironique dès le départ, mais soyez tranquille, cela va empirer.
+
+Vous allez obtenir trois choses :
+
+1. **comment les cinq compétences** sont assemblées en chaîne, avec de vrais nombres de lignes de ce commit,
+2. **pourquoi le prompt seul n'a pas suffi** et pourquoi j'ai dû ajouter un code déterministe pour corriger ce que le modèle menteur,
+3. **comment cet article a réellement été créé**, car c'est la meilleure preuve que le pipeline fonctionne, et non seulement qu'il a l'air joli dans le README.
+
+## Ce que j'ai réellement assemblé
+
+Le commit `d10b1b1` (#6, hier) a ajouté au repo cinq fichiers `.claude/skills/*/SKILL.md`, deux documents de référence sous `_shared/`, un module TypeScript avec des tests et un script bash pour vérifier le rendu. En chiffres :
+
+```
+.claude/skills/_shared/definition-of-done.md |  27 ++
+.claude/skills/_shared/failure-modes.md      |  65 ++
+.claude/skills/draft-post-fr/SKILL.md        | 127 ++
+.claude/skills/open-post-pr/SKILL.md         |  66 ++
+.claude/skills/propose-topics/SKILL.md       |  72 ++
+.claude/skills/translate-post/SKILL.md       |  64 ++
+.claude/skills/verify-post/SKILL.md          |  94 ++
+scripts/fix-integrity.ts                     | 126 ++
+scripts/verify-post-render.sh                | 110 ++
+src/lib/post-integrity.test.ts               | 185 ++
+src/lib/post-integrity.ts                    | 228 ++
+```
+
+Les cinq compétences sont cinq étapes distinctes, chacune avec une entrée et une sortie clairement définies, et non un seul grand prompt du type "écrivez-moi un article de blog et tout ce qui va avec" :
+
+1. **propose-topics.** Lit le `git log` et les métadonnées des articles existants, et propose soit 3 à 5 sujets ancrés dans l'activité réelle du repo, soit dit honnêtement qu'il n'y a rien à écrire cette semaine. Cet article est sorti de là, en tant que première position dans la liste.
+2. **draft-post-fr.** Écrit le `fr.mdx` dans ma voix, en imitant le dernier article publié, avec un FAQ obligatoire, une section Liens et un contre-argument, si le sujet implique une décision.
+3. **translate-post.** Appelle l'existant `bun run translate:post` (Groq, `llama-3.3-70b-versatile`), puis déclenche immédiatement le correctif d'intégrité sur le fichier fraîchement créé.
+4. **verify-post.** Passe par neuf portes de définition de terminaison et bloque le PR si l'une d'elles ne passe pas.
+5. **open-post-pr.** Crée une branche `claude/post-<slug>`, commit les parties logiques et ouvre un PR vers `dev`. Ne merge jamais.
+
+Chaque compétence fait référence à deux documents communs au lieu de répéter la même liste cinq fois : `definition-of-done.md` avec neuf portes DoD-1 à DoD-9 et `failure-modes.md` avec six modes de défaillance connus, F1 à F6. Ce n'est pas un ornement, mais une décision concrète : si quelque chose se casse un jour, la correction va dans un seul endroit, et non dans cinq fichiers distincts qui doivent être synchronisés.
+
+## Pourquoi le prompt seul n'a pas suffi
+
+Voici l'essentiel, et voici où la recherche de la veille au soir, au prix d'une semaine de réécriture du framework, m'a finalement servi, car j'avais la tête claire pour le calculer au lieu de simplement faire un geste : deux modes de défaillance dans `failure-modes.md` sont fermés par du code, et non par un prompt, car le prompt mentait régulièrement :
+
+**F3, traduction du slug.** Le modèle traduisait les mots à l'intérieur des slug URL, car ils ressemblent à du texte à traduire, mais ils sont des identificateurs. Un exemple concret de l'historique de ce repo : `/blog/de/proxmox-czesc-druga` changeait en `/blog/de/proxmox-teil-zwei`, ce qui donnait un 404 pur. J'ai demandé au prompt de ne pas le faire. Ça n'a pas fonctionné de manière cohérente.
+
+**F6, majuscules dans le frontmatter, détectées hier lors du retest complet de la chaîne.** Groq renvoie parfois un fragment de prompt avec un bloc de référence `TITLE:`, `DESCRIPTION:`, `DATE:` comme des clés de sortie valides. Puisque `parseFrontmatter` dans `src/lib/blog.ts` est sensible à la casse, `metadata.title` devient `undefined`, et `src/lib/related-posts.ts` appelle `tokenize(metadata.title)` sans protection lors du prerender. Résultat : `undefined.toLowerCase()` fait planter `bun run build` pour toute la page, et non pour un seul article. Une seule mauvaise traduction pouvait bloquer tout le déploiement.
+
+Alors, j'ai écrit `src/lib/post-integrity.ts`, un module pur sans accès au disque, trois fonctions l'une après l'autre :
+
+```ts
+export function fixPostIntegrity(
+  canonicalSlug: string,
+  translatedContent: string,
+  options?: PostIntegrityOptions
+): PostIntegrityFixResult {
+  parseFrontmatter(translatedContent) // jette si le frontmatter manque
+
+  const slugResult = rewriteInternalSlugLinks(translatedContent, canonicalSlug, knownSlugs)
+  const caseResult = normalizeFrontmatterKeyCasing(slugResult.content)
+  const tagResult = reinsertCanonicalTags(caseResult.content, canonicalTags)
+
+  return { changed: fixes.length > 0, fixes, content: tagResult.content }
+}
+```
+
+`rewriteInternalSlugLinks` réécrit chaque lien `](/blog/<lang>/<slug>)`, dont le slug n'est pas un répertoire connu, en slug canonique. `normalizeFrontmatterKeyCasing` ramène `TITLE:` à `title:`, en touchant uniquement le nom de la clé, la valeur reste inchangée. `reinsertCanonicalTags` rattache ou remplace la ligne `tags`, si elle a disparu ou s'est décalée avec les autres langues. L'ordre à l'intérieur est important : la normalisation de la casse des lettres passe avant la gestion des tags, car sinon `TAGS:` avec une casse des lettres décalée passerait inaperçu lors de la vérification des tags. Jusqu'à neuf tests dans `post-integrity.test.ts`, donc ces trois fonctions ont une couverture réelle, et non seulement ma parole.
+
+C'est la différence entre "j'ai demandé au modèle de ne pas le faire" et "physiquement, il n'est pas possible de l'envoyer en PR". Les prompts sont fiables à peu près autant que les gens après leur troisième café : ils fonctionnent, jusqu'à ce qu'ils ne fonctionnent plus, et alors, ils s'effondrent silencieusement.
+
+## Quand le prompt suffit tout de même
+
+Honnêtement, dans l'autre sens, car les cinq compétences ne signifient pas que tout doit être du code. `propose-topics` et `draft-post-fr` restent des prompts purs, et c'est une décision consciente, et non de la paresse. L'évaluation de savoir si un commit de la semaine dernière vaut un article à part entière, ou si une phrase sonne comme moi et non comme du texte généré, ce sont des tâches que l'on ne peut pas fermer dans un regex. Le code déterministe ne reçoit que les deux choses qui ont une seule réponse correcte, vérifiable par programme : si le slug existe en tant que répertoire et si la ligne `tags` est identique dans les quatre langues. Tout ce qui nécessite un jugement reste un prompt avec une porte de vérification dure à la fin, qui le vérifie. Code déterministe là où il y a une seule réponse correcte, prompt là où il faut évaluer et non compter, et aucun des deux ne fait semblant de l'autre.
+
+## Comment cet article a réellement été créé
+
+Et maintenant, cette ironique cerise sur le gâteau que j'ai promise au début. `propose-topics` a regardé le `git log` des derniers jours, a vu le commit `d10b1b1` et m'a proposé de l'écrire en tant que première position dans la liste des sujets, avec une raison concrète : les cinq nouvelles compétences plus le correctif déterministe étaient arrivés dans le repo la veille. J'ai répondu "1". `draft-post-fr` a lu le dernier article publié pour attraper le rythme, a extrait les vrais nombres de lignes et le vrai code de ce même commit, et a écrit ce que vous lisez maintenant. Le même pipeline, dont vous venez de lire, a produit le texte qui en parle. Ce n'est pas une grande astuce récursive, mais simplement l'effet naturel du fait que j'ai construit un outil et que je l'ai utilisé immédiatement, mais j'avoue que lorsque cela m'est venu à l'esprit pendant l'écriture, j'ai trouvé cela un peu drôle.
+
+## FAQ
+
+**Pourquoi cinq compétences distinctes, et non un seul grand prompt pour tout le processus ?**
+Parce que chaque étape a une entrée différente, une sortie différente et une manière différente de vérification. Un seul grand prompt ne peut pas s'arrêter en cours de route, quand la traduction coupe une section ou perd un tag. Cinq étapes distinctes avec une porte de vérification dure entre elles peuvent.
+
+**Est-ce que ces compétences génèrent automatiquement quelque chose pour la production ?**
+Non. `open-post-pr` se termine par l'ouverture d'un PR vers `dev` et ne merge jamais ni ne pousse vers `dev` ou `prod` directement. La publication est toujours un mouvement manuel, je lis le PR et je le merge moi-même.
+
+**Qu'est-ce que le correctif déterministe fait exactement, que le prompt ne faisait pas de manière fiable ?**
+Il réécrit les slug traduits en slug canoniques (F3), normalise la casse des lettres des clés frontmatter comme `TITLE:` en `title:` (F6) et rattache à nouveau la ligne `tags` manquante (F4). Tout cela est du code dans `src/lib/post-integrity.ts`, et non une autre instruction dans le prompt.
+
+**Que se passe-t-il si Groq épuise la limite quotidienne de tokens pendant la traduction ?**
+`translate-post` attrape cette erreur spécifique et, au lieu d'attendre des heures, traduit les autres langues avec le modèle de l'agent qui conduit actuellement la session, en gardant toujours les mêmes portes DoD-4 et DoD-5. À la fin, j'obtiens un rapport sur lesquels des langues sont passés par Groq et lesquels par ce chemin de secours.
+
+**Comment vérifiez-vous que les quatre versions de l'article se rendent bien ?**
+`scripts/verify-post-render.sh` fait un build dans la même session, démarre un serveur local et curl les quatre pages plus l'URL de l'image OG, en vérifiant le code 200 réel, et non seulement l'absence d'erreur lors du build.
+
+## Conclusion
+
+J'ai terminé avec cinq fichiers de compétences, un module TypeScript avec neuf tests et un article qui se prouve lui-même. La prochaine fois, si quelque chose dans cette chaîne se casse, je saurai exactement où : soit dans l'une des deux portes que le code corrige, soit dans l'une des sept portes qui échouent dur et m'attendent. 
+
+Et honnêtement : j'avais promis il y a trois jours que je reviens aux tutoriels classiques sur l'hébergement auto. J'ai rompu cette promesse pour écrire un article sur le système qui m'a lui-même proposé de la rompre, qui l'a écrit dans mon style et qui l'aurait vérifié s'il n'attendait pas juste mon merge manuel. La seule différence entre moi il y a trois jours et moi maintenant est que cette fois, j'ai un outil qui veillera au moins à ce que les liens ne se cassent pas. L'hébergement auto revient la prochaine fois. À moins que quelque chose ne se réécrive encore une fois tout seul.
+
+## Liens
+
+- [Article précédent, dans lequel j'ai promis la fin de la série sur le blog et les agents](/blog/fr/why-i-didnt-rewrite-my-blog-to-a-new-framework)
+- [Article sur les hooks et les compétences dans Claude Code, point de départ pour ce pipeline](/blog/fr/how-to-setup-claude-code-hooks-skills)
+- [Comment LLaMA a mélangé mes slug dans les traductions, ou la raison profonde de F3](/blog/fr/llm-translated-my-blog-and-broke-the-links)
+- [Mon propre serveur MCP, par lequel je vérifie le trafic sur le blog](/blog/fr/how-to-build-mcp-server-for-analytics)
+- [Claude Code, documentation des compétences](https://docs.claude.com/en/docs/claude-code)
+- [Groq, fournisseur du modèle de traduction](https://groq.com)

--- a/content/posts/five-claude-code-skills-blog-pipeline/pl.mdx
+++ b/content/posts/five-claude-code-skills-blog-pipeline/pl.mdx
@@ -1,0 +1,116 @@
+---
+title: "Zbudowałem sobie redakcyjny pipeline z pięciu skilli Claude Code"
+description: "Pięć skilli Claude Code złożonych w łańcuch zamiast jednego wielkiego promptu do pisania bloga. Plus deterministyczny fixer, bo prompty kłamią o slugach."
+date: 2026-07-09T12:00:00.000Z
+tags: claude-code, ai, agenty, skille, automatyzacja, blog, redakcja, workflow
+---
+
+## Wprowadzenie
+
+W poprzednim wpisie napisałem zdanie, które teraz brzmi jak żart: "na tym domykam serię o dłubaniu przy blogu i agentach, następnym razem wracam do normalnych how-to". To było trzy dni temu. Dziś siedzę i piszę kolejny wpis o dłubaniu przy blogu i agentach, tyle że tym razem sam ten wpis powstał w części dzięki temu, o czym pisze. Do tego jeszcze wrócę, bo to jest cała pointa tego tekstu, ale najpierw powód, czemu w ogóle złamałem obietnicę.
+
+Miałem dość ręcznego pisania postów. Nie samego pisania, tego lubię, tylko tego co dookoła: tłumaczenie na trzy języki, pilnowanie żeby linki w tłumaczeniach wskazywały na prawdziwe slugi, sprawdzanie czy `tags` nie zniknęły po drodze, budowanie strony i klikanie po czterech wersjach jednego posta, żeby sprawdzić czy się w ogóle renderują. Za każdym razem robiłem to ręcznie i za każdym razem coś umykało. Więc zamiast pisać kolejnego posta, spędziłem dwa dni pisząc coś, co ma pisać posty za mnie. Ironiczne już na starcie, ale spokojnie, będzie gorzej.
+
+Dostaniesz trzy rzeczy:
+
+1. **jak wygląda pięć skilli** złożonych w łańcuch, z prawdziwymi liczbami linii z tego commita,
+2. **czemu sam prompt nie wystarczył** i musiałem dopisać deterministyczny kod, który poprawia to, co model kłamie,
+3. **jak ten konkretny wpis powstał**, bo to jest najlepszy dowód na to, czy pipeline działa, czy tylko ładnie wygląda w README.
+
+## Co właściwie skleiłem
+
+Commit `d10b1b1` (#6, wczoraj) dorzucił do repo pięć plików `.claude/skills/*/SKILL.md`, dwa dokumenty referencyjne pod `_shared/`, jeden moduł TypeScript z testami i skrypt bashowy do sprawdzania renderu. W liczbach:
+
+```
+.claude/skills/_shared/definition-of-done.md |  27 ++
+.claude/skills/_shared/failure-modes.md      |  65 ++
+.claude/skills/draft-post-pl/SKILL.md        | 127 ++
+.claude/skills/open-post-pr/SKILL.md         |  66 ++
+.claude/skills/propose-topics/SKILL.md       |  72 ++
+.claude/skills/translate-post/SKILL.md       |  64 ++
+.claude/skills/verify-post/SKILL.md          |  94 ++
+scripts/fix-integrity.ts                     | 126 ++
+scripts/verify-post-render.sh                | 110 ++
+src/lib/post-integrity.test.ts               | 185 ++
+src/lib/post-integrity.ts                    | 228 ++
+```
+
+Pięć skilli to pięć osobnych kroków, każdy z jasno opisanym wejściem i wyjściem, a nie jeden wielki prompt typu "napisz mi wpis na bloga i wszystko dookoła":
+
+1. **propose-topics.** Czyta `git log` i frontmatter istniejących postów, i albo proponuje 3 do 5 tematów zakotwiczonych w realnej aktywności repo, albo uczciwie mówi, że w tym tygodniu nie ma o czym pisać. Ten wpis właśnie stąd wyszedł, jako pozycja numer jeden na liście.
+2. **draft-post-pl.** Pisze `pl.mdx` w moim głosie, naśladując najnowszy opublikowany post, z obowiązkowym FAQ, sekcją Linki i kontrargumentem, jeśli temat niesie jakąś decyzję.
+3. **translate-post.** Woła istniejący `bun run translate:post` (Groq, `llama-3.3-70b-versatile`), po czym od razu odpala fixer integralności na świeżo powstałym pliku.
+4. **verify-post.** Przejeżdża przez dziewięć bramek Definition of Done i blokuje PR, jeśli którakolwiek nie przejdzie.
+5. **open-post-pr.** Zakłada branch `claude/post-<slug>`, commituje logicznymi kawałkami i otwiera PR do `dev`. Nigdy nie mergeuje.
+
+Każdy skill linkuje do dwóch wspólnych dokumentów zamiast powtarzać tę samą listę pięć razy: `definition-of-done.md` z dziewięcioma bramkami DoD-1 do DoD-9 i `failure-modes.md` z sześcioma znanymi trybami awarii, F1 do F6. To nie jest ozdobnik, tylko konkretna decyzja: jak coś się kiedyś popsuje, poprawka trafia w jedno miejsce, a nie w pięć osobnych plików, które trzeba pamiętać zsynchronizować.
+
+## Czemu sam prompt nie wystarczył
+
+Tu jest sedno, i tu poprzedni wieczór research kosztem tygodnia przepisywania frameworka nagle się przydał, bo miałem jasną głowę żeby to policzyć zamiast znowu machnąć ręką. Dwa tryby awarii z `failure-modes.md` są zamknięte kodem, nie promptem, bo sam prompt regularnie kłamał:
+
+**F3, tłumaczenie sluga.** Model tłumaczył słowa wewnątrz slugów URL, bo wyglądają jak tekst do przetłumaczenia, a są identyfikatorem. Konkretny przykład z historii tego repo: `/blog/de/proxmox-czesc-druga` zmieniało się w `/blog/de/proxmox-teil-zwei`, co dawało czyste 404. Kazałem promptowi tego nie robić. Nie pomogło konsekwentnie.
+
+**F6, wielkie litery we frontmatterze, wykryte wczoraj podczas pełnego retestu łańcucha.** Groq czasem odbija fragment promptu z referencyjnym blokiem `TITLE:`, `DESCRIPTION:`, `DATE:` jako właściwe klucze wyjścia. Ponieważ `parseFrontmatter` w `src/lib/blog.ts` jest case sensitive, `metadata.title` staje się `undefined`, a `src/lib/related-posts.ts` woła `tokenize(metadata.title)` bez zabezpieczenia w trakcie prerenderu. Efekt: `undefined.toLowerCase()` wywala `bun run build` dla całej strony, nie dla jednego posta. Jedno kiepskie tłumaczenie mogło zablokować cały deploy.
+
+Więc napisałem `src/lib/post-integrity.ts`, czysty moduł bez dostępu do dysku, trzy funkcje jedna po drugiej:
+
+```ts
+export function fixPostIntegrity(
+  canonicalSlug: string,
+  translatedContent: string,
+  options?: PostIntegrityOptions
+): PostIntegrityFixResult {
+  parseFrontmatter(translatedContent) // rzuca na brak frontmatteru
+
+  const slugResult = rewriteInternalSlugLinks(translatedContent, canonicalSlug, knownSlugs)
+  const caseResult = normalizeFrontmatterKeyCasing(slugResult.content)
+  const tagResult = reinsertCanonicalTags(caseResult.content, canonicalTags)
+
+  return { changed: fixes.length > 0, fixes, content: tagResult.content }
+}
+```
+
+`rewriteInternalSlugLinks` przepisuje każdy link `](/blog/<lang>/<slug>)`, którego slug nie jest znanym katalogiem, z powrotem na kanoniczny. `normalizeFrontmatterKeyCasing` sprowadza `TITLE:` do `title:`, dotykając wyłącznie nazwy klucza, wartość zostaje bajt w bajt taka sama. `reinsertCanonicalTags` dokleja albo podmienia linię `tags`, jeśli zniknęła lub się rozjechała z resztą języków. Kolejność w środku ma znaczenie: normalizacja wielkości liter idzie przed obsługą tagów, bo inaczej `TAGS:` z rozjechaną wielkością liter przeleciałoby obok sprawdzenia tagów niezauważone. Do tego dziewięć testów w `post-integrity.test.ts`, więc te trzy funkcje mają realne pokrycie, a nie tylko moje słowo.
+
+To jest różnica między "kazałem modelowi żeby tego nie robił" a "fizycznie nie da się tego wysłać do PR-a". Prompty są niezawodne mniej więcej tak samo jak ludzie po trzeciej kawie: działają, dopóki nie działają, a wtedy walą się cicho.
+
+## Kiedy sam prompt jednak wystarcza
+
+Uczciwie w drugą stronę, bo pięć skilli nie znaczy, że wszystko musi być kodem. `propose-topics` i `draft-post-pl` zostają czystym promptem, i to jest świadoma decyzja, nie lenistwo. Ocena, czy commit z ostatniego tygodnia jest "wart osobnego wpisu", albo czy zdanie brzmi jak ja, a nie jak wygenerowany tekst, to zadania, których nie da się zamknąć w regexie. Kod deterministyczny dostają wyłącznie dwie rzeczy, które mają jedną poprawną odpowiedź, sprawdzalną programowo: czy slug istnieje jako katalog i czy linia `tags` jest identyczna w czterech językach. Wszystko, co wymaga osądu, zostaje promptem z twardą bramką na końcu, która go weryfikuje. Deterministyczny kod tam, gdzie jest jedna poprawna odpowiedź, prompt tam, gdzie trzeba ocenić, a nie policzyć, i żadne z tych dwóch nie udaje drugiego.
+
+## Jak ten wpis naprawdę powstał
+
+A teraz ta ironiczna wisienka, którą obiecałem na początku. `propose-topics` przejrzał git log z ostatnich dni, zobaczył commit `d10b1b1` i zaproponował mi go jako pozycję numer jeden na liście tematów, z konkretnym uzasadnieniem: pięć nowych skilli plus deterministyczny fixer trafiły do repo dzień wcześniej. Odpisałem "1". `draft-post-pl` przeczytał najnowszy opublikowany wpis, żeby złapać rytm, wyciągnął prawdziwe liczby linii i prawdziwy kod z tego samego commita, i napisał to, co teraz czytasz. Ten sam pipeline, o którym właśnie przeczytałeś, wyprodukował tekst, który o nim czytasz. Nie jest to jakaś wielka rekurencyjna sztuczka, po prostu naturalny efekt tego, że zbudowałem narzędzie i od razu go użyłem, ale przyznaję, że kiedy to do mnie dotarło w trakcie pisania, zrobiło mi się trochę śmiesznie.
+
+## FAQ
+
+**Czemu pięć osobnych skilli, a nie jeden wielki prompt na cały proces?**
+Bo każdy krok ma inne wejście, inne wyjście i inny sposób weryfikacji. Jeden wielki prompt nie potrafi w środku sam siebie zatrzymać, kiedy tłumaczenie urwie sekcję albo zgubi tag. Pięć osobnych kroków z twardą bramką między nimi potrafi.
+
+**Czy te skille cokolwiek generują automatycznie na produkcję?**
+Nie. `open-post-pr` kończy na otwarciu PR-a do `dev` i nigdy nie mergeuje ani nie pushuje do `dev` czy `prod` bezpośrednio. Publikacja to zawsze ręczny ruch, ja czytam PR i sam go mergeuję.
+
+**Co konkretnie robi deterministyczny fixer, czego prompt nie robił niezawodnie?**
+Przepisuje przetłumaczone slugi z powrotem na kanoniczne (F3), normalizuje wielkość liter kluczy frontmattera jak `TITLE:` na `title:` (F6) i dokleja z powrotem brakującą linię `tags` (F4). Wszystko to kod w `src/lib/post-integrity.ts`, nie kolejna instrukcja w prompcie.
+
+**Co się dzieje, jak Groq wyczerpie dzienny limit tokenów w trakcie tłumaczenia?**
+`translate-post` łapie ten konkretny błąd i zamiast czekać godzinami, tłumaczy pozostałe języki modelem agenta, który akurat prowadzi sesję, cały czas pilnując tych samych bramek DoD-4 i DoD-5. Na końcu dostaję raport, które języki poszły przez Groqa, a które przez ten zapasowy tor.
+
+**Jak sprawdzasz, że wszystkie cztery wersje posta w ogóle się renderują?**
+`scripts/verify-post-render.sh` robi build w tej samej sesji, odpala lokalny serwer i curl-uje wszystkie cztery strony plus URL obrazka OG, sprawdzając realny kod 200, a nie tylko brak błędu przy buildzie.
+
+## Podsumowanie
+
+Skończyłem z pięcioma plikami skilli, jednym modułem TypeScript z dziewięcioma testami i jednym wpisem, który sam siebie udowadnia. Następnym razem, jak coś w tym łańcuchu się posypie, będę wiedział dokładnie gdzie: albo w jednej z dwóch bramek, które naprawia kod, albo w jednej z siedmiu, które twardo failują i czekają na mnie.
+
+I teraz uczciwie: obiecałem trzy dni temu, że wracam do normalnych how-to o self-hostingu. Złamałem tę obietnicę, żeby napisać wpis o systemie, który sam zaproponował mi jej złamanie, sam go napisał w moim stylu i sam by go zweryfikował, gdyby akurat nie czekał teraz na mój ręczny merge. Jedyna różnica między mną sprzed trzech dni a mną teraz jest taka, że tym razem mam narzędzie, które przynajmniej dopilnuje, żeby linki się nie posypały. Self-hosting wraca następnym razem. Chyba że coś znowu mi się dopisze samo.
+
+## Linki
+
+- [Poprzedni wpis, w którym obiecałem koniec serii o blogu i agentach](/blog/pl/why-i-didnt-rewrite-my-blog-to-a-new-framework)
+- [Wpis o hookach i skillach w Claude Code, punkt wyjścia do tego pipeline'u](/blog/pl/how-to-setup-claude-code-hooks-skills)
+- [Jak llama pomieszała mi slugi w tłumaczeniach, czyli praprzyczyna F3](/blog/pl/llm-translated-my-blog-and-broke-the-links)
+- [Własny serwer MCP, przez który sprawdzam ruch na blogu](/blog/pl/how-to-build-mcp-server-for-analytics)
+- [Claude Code, dokumentacja skilli](https://docs.claude.com/en/docs/claude-code)
+- [Groq, dostawca modelu tłumaczącego](https://groq.com)


### PR DESCRIPTION
## tl;dr

New post: **"Zbudowałem sobie redakcyjny pipeline z pięciu skilli Claude Code"** (en: *I Built a Five-Skill Editorial Pipeline with Claude Code*). Walks through the five chained `.claude/skills/*` from commit `d10b1b1` (#6), why two failure modes (F3 slug translation, F6 uppercase frontmatter keys) needed deterministic code instead of prompt instructions, and closes on the fact that this very post was produced by the pipeline it describes.

Topic selected via `propose-topics` candidate #1, grounded in commit `d10b1b1` (2026-07-08).

## DoD checklist

| Gate | Result |
|---|---|
| DoD-1 Voice / em dashes | PASS — zero em dashes across all 4 files, no AI-tell phrases found |
| DoD-2 Completeness | PASS — `pl`, `en`, `de`, `fr` all present |
| DoD-3 No truncation | PASS — en 108%, de 114%, fr 124% of `pl` word count; all 8 `##` section headers present in every translation |
| DoD-4 Canonical slugs | PASS — 4 internal links per translation, all point at real `content/posts/` directories (verified with `fix:post-integrity`, no changes needed on re-run) |
| DoD-5 Tags | PASS — identical `tags:` line across all four files: `claude-code, ai, agenty, skille, automatyzacja, blog, redakcja, workflow` |
| F5 Stray markup / secrets | PASS — no tool-call markup, no `gsk_...`-shaped strings, all files end cleanly |
| DoD-6 OG | PASS — `coverImage` absent in all 4 files (dynamic OG in use); `og:image` returned HTTP 200 for pl/en/de/fr; tags resolve to the `claude-code`/`agenty` theme (`claude @ dev.paczesny.pl` terminal card) |
| DoD-7 Renders | PASS — `scripts/verify-post-render.sh` build + local server + curl: all 4 pages and the OG route returned 200 |
| DoD-8 Frontmatter | PASS — `description` ≤160 chars on all 4 (pl 153, en 154, de 143, fr 155), valid `date`, well-formed `tags` |
| DoD-9 Post-deploy sitemap | deferred (Phase D, not run here) |

**Manual fix applied during verification (new failure pattern, not yet covered by the deterministic fixer):** the Groq translations for en/de/fr came back with a malformed frontmatter block — a stray YAML list (`- claude-code` / `- blog` / ...) left dangling after the `tags:` line once `fix:post-integrity` rewrote it, plus a hallucinated `coverImage:` key (empty on en, pointing at a nonexistent `/assets/blog/cover-image.jpg` on de/fr). `fix:post-integrity` only rewrites the `tags:` line itself, not stray continuation lines, so this slipped past the automated fixer. Removed the stray lines and the `coverImage` key by hand on all three translations to match `pl.mdx`'s frontmatter shape exactly; re-ran `fix:post-integrity` afterward (clean, no further changes) and confirmed `bun run build` succeeds. Also trimmed the de/fr `description` lines, which came back over the 160-char cap (212 and 171 chars). Flagging this as a candidate F7 for `_shared/failure-modes.md` — worth a follow-up so the fixer strips stray list continuation lines after a scalar `tags:`/`coverImage:` rewrite.

## Internal links added

- `/blog/<lang>/why-i-didnt-rewrite-my-blog-to-a-new-framework`
- `/blog/<lang>/how-to-setup-claude-code-hooks-skills`
- `/blog/<lang>/llm-translated-my-blog-and-broke-the-links`
- `/blog/<lang>/how-to-build-mcp-server-for-analytics`

(each present in all four language files, `<lang>` = pl/en/de/fr)

## Verification evidence

- `bun run build` succeeded (113 static pages generated, no crash — this also confirms the frontmatter fix above actually closed the F6-shaped risk for this post).
- `scripts/verify-post-render.sh five-claude-code-skills-blog-pipeline`: all 4 language pages (`/blog/{pl,en,de,fr}/five-claude-code-skills-blog-pipeline`) and `/og/post` for all 4 languages returned HTTP 200.
- `fix:post-integrity` run per language after translation and again after the manual frontmatter cleanup: reports `no fixes needed` on the final pass for en/de/fr.
- Word count and `##` header parity checked pl vs. en/de/fr: 8/8 headers present in every language, no dropped sections.
- Translation provenance: en, de, fr all produced by Groq (`llama-3.3-70b-versatile`); no TPD/TPM cap hit, no agent-fallback path used.
- Grepped all 4 files for stray tool-call markup and secret-shaped strings: none found.

## OG image preview (per language)

Local render, same query shape verify-post's DoD-6 check hit against `http://localhost:3000` this session:

- pl: `/og/post?title=Zbudowa%C5%82em+sobie+redakcyjny+pipeline+z+pi%C4%99ciu+skilli+Claude+Code&lang=pl&tags=claude-code%2C+ai%2C+agenty%2C+skille%2C+automatyzacja%2C+blog%2C+redakcja%2C+workflow`
- en: `/og/post?title=I+Built+a+Five-Skill+Editorial+Pipeline+with+Claude+Code&lang=en&tags=claude-code%2C+ai%2C+agenty%2C+skille%2C+automatyzacja%2C+blog%2C+redakcja%2C+workflow`
- de: `/og/post?title=Ich+habe+mir+eine+redaktionelle+Pipeline+mit+f%C3%BCnf+Claude-Code-Skills+aufgebaut&lang=de&tags=claude-code%2C+ai%2C+agenty%2C+skille%2C+automatyzacja%2C+blog%2C+redakcja%2C+workflow`
- fr: `/og/post?title=J%27ai+construit+un+pipeline+%C3%A9ditorial+avec+cinq+comp%C3%A9tences+Claude+Code&lang=fr&tags=claude-code%2C+ai%2C+agenty%2C+skille%2C+automatyzacja%2C+blog%2C+redakcja%2C+workflow`

All four resolve to the `claude-code`/`agenty` theme (the "claude @ dev.paczesny.pl" terminal card), matching the topic. Append any of the above paths to your local `bun run start` origin to eyeball them, since this environment has no public preview deploy.

---

Never merged, never pushed to `dev`/`prod` directly — only this `claude/post-five-claude-code-skills-blog-pipeline` branch was pushed. Ready for your read-through and merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKh9PbPTJVzsjftXwNKzM7)_