### PR TITLE
docs: add blog editorial agent operator docs pointer to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Project rules (dev.paczesny.pl)
+
+Personal site + blog. Repo: bartosz-skejcik/dev.paczesny.pl. Deploys via Coolify on push (verify the branch with `git branch -vv` before assuming).
+
+## Blog voice (non-negotiable)
+Casual Polish, first person, written as a live struggle-journey: numbered goals, slang and profanity welcome, ends on an ironic lesson. It must NOT read as polished AI prose. Before drafting any post: load the `creative-writing-skills:llm-writing` skill and match existing posts in the repo; when in doubt, imitate the last published post, not "good writing".
+
+- No em dashes, in Polish or English.
+- Draft → Bartek reads → only then publish. Never push a post live without an explicit OK.
+Blog editorial agent operator docs: paczesny-dev/claude-toolkit, blog-agent/ folder (README, routine prompts, setup checklist).


### PR DESCRIPTION
Restores the project `CLAUDE.md` onto `dev`, which currently has no `CLAUDE.md` at all.

The file plus the operator-docs pointer line were previously committed only on `claude/routine-a-ideation` (commit 9ba8b50). That branch was squash-merged into `dev` via PR #7, which orphaned its individual commits, and the squash did not bring `CLAUDE.md` onto `dev`. A future `git checkout dev` in the working directory would therefore delete the file entirely.

This PR cherry-picks that single commit onto a branch off current `dev` so `CLAUDE.md` lives on `dev` with the pointer line intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)