### PR TITLE
fix: post-integrity F7 hardening, PR-body em dash guard, open-post-pr doc fixes

### DIFF
--- a/.claude/skills/_shared/failure-modes.md
+++ b/.claude/skills/_shared/failure-modes.md
@@ -1,8 +1,8 @@
 # Known failure modes and required mitigations
 
 Learned the hard way during the manual dry run. The system must handle all of them. The five blog
-skills link here by name instead of repeating the list. F3 and F4 are closed by deterministic code:
-`src/lib/post-integrity.ts`, invoked via `bun run fix:post-integrity --slug <slug> --lang <lang>`.
+skills link here by name instead of repeating the list. F3, F4, F6, and F7 are closed by deterministic
+code: `src/lib/post-integrity.ts`, invoked via `bun run fix:post-integrity --slug <slug> --lang <lang>`.
 
 ## F1. Groq daily token cap (TPD 100000 per day)
 
@@ -63,3 +63,20 @@ any case variant of a known frontmatter key back to its canonical lowercase form
 untouched), run via `bun run fix:post-integrity`. Since `translate-post` already mandates the fixer after
 every translation, the crashing case can no longer reach the build. Prompts are unreliable for this at
 temperature 0.2, so the guard is code, not prose.
+
+## F7. Stray tags list continuations and dangling coverImage
+
+Seen twice in production and both times fixed by hand during verification (the PRs that produced
+`i-made-my-blog-nag-me-on-slack` and `five-claude-code-skills-blog-pipeline`), never by the fixer. A
+translation left a leftover YAML list under the tags line, a `- claude-code` / `- blog` block from a prior
+malformed tags block, after the tags line itself was already a canonical scalar. Separately, a
+hallucinated `coverImage` pointed at an empty value or a file that does not exist. The dangling list
+corrupts the frontmatter shape, and a bogus `coverImage` overrides the dynamic per topic OG with a broken
+cover (DoD-6).
+
+Mitigation: the deterministic step `stripStrayFrontmatterContinuations` in `src/lib/post-integrity.ts`
+removes any `- ` list line immediately under a scalar tags line, and removes a `coverImage` line whose
+value is empty or whose asset does not exist. Existence is resolved by the CLI (`public/` rooted, the same
+way the app resolves image paths), so the library itself stays filesystem free. It runs last in
+`fixPostIntegrity`, after tags has been canonicalized so any list below it is unambiguously stray, and is
+invoked via `bun run fix:post-integrity`. Prompts are unreliable here, so the guard is code, not prose.

--- a/.claude/skills/open-post-pr/SKILL.md
+++ b/.claude/skills/open-post-pr/SKILL.md
@@ -32,14 +32,8 @@ without his explicit OK (Repo B `CLAUDE.md`).
    One commit per logical unit: the draft, the translations, and any integrity fixes. Only the branch is
    pushed, and only a `claude/`-prefixed branch. Never `dev`, never `prod`.
 
-2. Open the PR against `dev`. There is no `.github` PR template in this repo, so construct the full body
-   yourself:
-
-   ```bash
-   gh pr create --base dev --head claude/post-<slug> --title "post: <title>" --body-file <body>
-   ```
-
-   The PR body must carry, in this order:
+2. Construct the full PR body into a file (`<body>`). There is no `.github` PR template in this repo, so
+   write the whole thing yourself. The body must carry, in this order:
    - **tl;dr:** one or two lines on what the post is.
    - **DoD checklist:** every gate with pass or fail, taken verbatim from the verify-post report.
    - **Internal links added:** the list of internal `/blog/<lang>/<slug>` links the post introduces.
@@ -51,7 +45,30 @@ without his explicit OK (Repo B `CLAUDE.md`).
      OG images by eye and compares them against the recent posts, so give him the links to glance at how
      each card actually looks, not just a pass line.
 
-3. Prepare the Slack summary content: the PR link, the tl;dr, and the DoD summary. This skill produces
+3. Run the deterministic em dash guard over the body file BEFORE opening the PR. DoD-1 forbids em dashes
+   (U+2014) everywhere, but verify-post's DoD-1 scan only reads the four content `.mdx` files, never this
+   generated body, and a generated PR body once shipped 13 em dashes past clean content files. Prompts do
+   not reliably keep them out, so the guard is code, not a reminder:
+
+   ```bash
+   bun run fix:em-dash --file <body>   # strips every U+2014, replacing each with a comma
+   ```
+
+   After this runs the body file is guaranteed to contain zero U+2014. Never open the PR from an
+   unguarded body.
+
+4. Open the PR against `dev` using the built-in GitHub PR tool. This is how the skill actually fires: the
+   last live runs opened the PR through the harness's built-in GitHub integration, not the `gh` CLI. Give
+   it base `dev`, head `claude/post-<slug>`, title `post: <title>`, and the guarded `<body>` file from
+   steps 2 and 3 as the PR body.
+
+   Fallback, only when the environment exposes no built-in GitHub tool: the `gh` CLI does the same thing.
+
+   ```bash
+   gh pr create --base dev --head claude/post-<slug> --title "post: <title>" --body-file <body>
+   ```
+
+5. Prepare the Slack summary content: the PR link, the tl;dr, and the DoD summary. This skill produces
    that content as structured output only. It does NOT call a Slack webhook: none exists in Repo B, and
    actual Slack delivery is a routine concern (Phase 2 or 3), not this skill's job.
 
@@ -60,6 +77,8 @@ without his explicit OK (Repo B `CLAUDE.md`).
 - Never merge the PR. Only Bartek merges.
 - Never push to `dev` or `prod`, directly or via the PR. Only the `claude/post-<slug>` branch is pushed.
 - The human publish gate is mandatory. The PR targets `dev` and stops there.
+- The PR body must pass the em dash guard (`bun run fix:em-dash --file <body>`) before the PR opens. A
+  body carrying U+2014 must never reach GitHub, even when the four content files are clean.
 
 ## Output
 

--- a/.claude/skills/verify-post/SKILL.md
+++ b/.claude/skills/verify-post/SKILL.md
@@ -34,6 +34,10 @@ The `slug`. The four post files live at `content/posts/<slug>/{pl,en,de,fr}.mdx`
 
 DoD-9 (post-deploy sitemap) is Phase D and is NOT run here.
 
+The DoD-1 em dash scan here covers the four content `.mdx` files only. The PR body that `open-post-pr`
+later generates is a separate surface, guarded there by its own deterministic em dash pass
+(`bun run fix:em-dash`), because clean content files do not guarantee a clean PR body.
+
 ## DoD-3 also compares section headers, not just word count
 
 The word-count ratio is not enough. On a long post the translator can silently drop a whole trailing

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "translate:top": "tsx scripts/pretranslate.ts",
     "translate:post": "tsx scripts/translate.ts",
     "fix:post-integrity": "tsx scripts/fix-integrity.ts",
+    "fix:em-dash": "tsx scripts/strip-em-dashes.ts",
     "describe:post": "tsx scripts/describe.ts",
     "test": "vitest run"
   },

--- a/scripts/fix-integrity.ts
+++ b/scripts/fix-integrity.ts
@@ -1,4 +1,5 @@
 import fs from "fs"
+import path from "path"
 import { CANONICAL_LANG, SUPPORTED_LANGS, type SupportedLang } from "@/lib/i18n"
 import { getPostFilePath, getPostSlugs, parseFrontmatter } from "@/lib/blog"
 import { fixPostIntegrity } from "@/lib/post-integrity"
@@ -100,6 +101,12 @@ function main() {
   const result = fixPostIntegrity(parsedSlug, targetContent, {
     knownSlugs,
     canonicalTags,
+    // Resolve a coverImage value the same way the app does (public/ rooted), so a
+    // dangling cover is stripped in favor of the dynamic OG. File I/O stays here.
+    coverImageAssetExists: (assetPath) =>
+      fs.existsSync(
+        path.join(process.cwd(), "public", assetPath.replace(/^\//, ""))
+      ),
   })
 
   if (!result.changed) {

--- a/scripts/strip-em-dashes.ts
+++ b/scripts/strip-em-dashes.ts
@@ -1,0 +1,65 @@
+import fs from "fs"
+import { stripEmDashes } from "@/lib/em-dash"
+
+/**
+ * Deterministic em dash guard for generated text, chiefly open-post-pr's PR body.
+ * Reads a file, strips every U+2014 (replacing each with a comma), writes it back,
+ * and reports the count. The end state is a guarantee, not a request: after this
+ * runs the file cannot contain an em dash, so a PR body can never carry one to
+ * GitHub regardless of how the prose was written.
+ *
+ * Usage: bun run fix:em-dash --file <path>
+ */
+function parseArgs() {
+  const argv = process.argv.slice(2)
+  let file: string | undefined
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i]
+    if (!token) {
+      continue
+    }
+
+    if (token === "--file" || token === "-f") {
+      file = argv[i + 1]
+      i += 1
+      continue
+    }
+
+    if (token.startsWith("--file=")) {
+      file = token.split("=")[1]
+      continue
+    }
+  }
+
+  return { file }
+}
+
+function main() {
+  const { file } = parseArgs()
+  if (!file) {
+    throw new Error(
+      "Missing --file argument. Usage: bun run fix:em-dash --file path/to/body.md"
+    )
+  }
+
+  const raw = fs.readFileSync(file, "utf-8")
+  const result = stripEmDashes(raw)
+
+  if (!result.changed) {
+    console.log(`✓ ${file}: no em dashes`)
+    return
+  }
+
+  fs.writeFileSync(file, result.text, "utf-8")
+  console.log(
+    `✓ ${file}: stripped ${result.count} em dash(es), replaced with commas`
+  )
+}
+
+try {
+  main()
+} catch (error) {
+  console.error(`✗ Failed stripping em dashes:`, (error as Error).message)
+  process.exitCode = 1
+}

--- a/src/lib/em-dash.test.ts
+++ b/src/lib/em-dash.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+
+import { stripEmDashes } from "@/lib/em-dash"
+
+const DASH = "\u2014"
+
+describe("stripEmDashes", () => {
+  it("replaces a spaced em dash with a comma", () => {
+    const result = stripEmDashes(`first part ${DASH} second part`)
+
+    expect(result.changed).toBe(true)
+    expect(result.count).toBe(1)
+    expect(result.text).toBe("first part, second part")
+    expect(result.text).not.toContain(DASH)
+  })
+
+  it("replaces an unspaced em dash and collapses a doubled run", () => {
+    expect(stripEmDashes(`a${DASH}b`).text).toBe("a, b")
+    expect(stripEmDashes(`a${DASH}${DASH}b`).text).toBe("a, b")
+  })
+
+  it("strips every em dash so none can survive, preserving line structure", () => {
+    const body = [
+      "## tl;dr",
+      `Deterministic guard ${DASH} no em dashes reach GitHub.`,
+      `- item one ${DASH} detail`,
+      `- item two ${DASH} detail`,
+    ].join("\n")
+
+    const result = stripEmDashes(body)
+
+    expect(result.count).toBe(3)
+    expect(result.text).not.toContain(DASH)
+    // Newlines and the two list items are preserved: still four lines.
+    expect(result.text.split("\n")).toHaveLength(4)
+    expect(result.text).toContain("- item one, detail")
+  })
+
+  it("is a no-op when there is no em dash", () => {
+    const clean = "already clean: commas, colons, periods."
+    const result = stripEmDashes(clean)
+
+    expect(result.changed).toBe(false)
+    expect(result.count).toBe(0)
+    expect(result.text).toBe(clean)
+  })
+})

--- a/src/lib/em-dash.ts
+++ b/src/lib/em-dash.ts
@@ -1,0 +1,38 @@
+// U+2014 EM DASH. This project forbids it everywhere, in any language, per both
+// CLAUDE.md files and DoD-1. Prose avoidance is not reliable: a generated PR body
+// once shipped 13 of them past a clean content check, so the guard is code, not a
+// prompt. Strip every em dash before the text can leave for GitHub. The character
+// is referenced below only via its Unicode escape, never as a literal glyph, so
+// this file itself stays clean under a mechanical em dash scan.
+
+// One run of em dashes with any surrounding spaces or tabs, so "a b", "ab", and a
+// doubled run all collapse to a single comma plus space. Only [ \t] is consumed
+// around the run, never newlines, so line structure, headings, and lists survive.
+const EM_DASH_RUN_REGEX = /[ \t]*\u2014[ \t\u2014]*/g
+
+// Counts individual em dashes for the report, independent of how they are grouped.
+const EM_DASH_GLOBAL_REGEX = /\u2014/g
+
+export type EmDashStripResult = {
+  text: string
+  count: number
+  changed: boolean
+}
+
+/**
+ * Deterministically remove every em dash (U+2014) from a block of text, replacing
+ * each run with a comma and a space, this project's default substitute (commas,
+ * periods, colons only). Pure. The returned text is guaranteed to contain no
+ * U+2014, which is the whole point: the caller can rely on that, not on prose
+ * discipline. No-op (text returned byte identical) when there is no em dash.
+ */
+export function stripEmDashes(text: string): EmDashStripResult {
+  const count = (text.match(EM_DASH_GLOBAL_REGEX) ?? []).length
+  if (count === 0) {
+    return { text, count: 0, changed: false }
+  }
+
+  const stripped = text.replace(EM_DASH_RUN_REGEX, ", ")
+
+  return { text: stripped, count, changed: true }
+}

--- a/src/lib/post-integrity.test.ts
+++ b/src/lib/post-integrity.test.ts
@@ -182,4 +182,150 @@ describe("fixPostIntegrity", () => {
       result.fixes.filter((fix) => fix.startsWith("frontmatter"))
     ).toHaveLength(0)
   })
+
+  it("strips stray YAML list continuations left under a canonical tags line", () => {
+    const content = [
+      "---",
+      "title: Skille",
+      "description: desc",
+      "date: 2026-07-08T12:00:00.000Z",
+      "tags: nextjs, proxmox, selfhosting",
+      "- nextjs",
+      "- proxmox",
+      "- selfhosting",
+      "---",
+      "",
+      "Body [self](/blog/de/proxmox-czesc-druga).",
+      "",
+    ].join("\n")
+
+    const result = fixPostIntegrity("proxmox-czesc-druga", content, {
+      knownSlugs: ["proxmox-czesc-druga"],
+      canonicalTags: ["nextjs", "proxmox", "selfhosting"],
+    })
+
+    expect(result.changed).toBe(true)
+    // The canonical scalar tags line survives.
+    expect(result.content).toContain("tags: nextjs, proxmox, selfhosting")
+    // Every dangling list continuation is gone.
+    expect(result.content).not.toMatch(/^- nextjs$/m)
+    expect(result.content).not.toMatch(/^- proxmox$/m)
+    expect(result.content).not.toMatch(/^- selfhosting$/m)
+    // The body self-link is untouched.
+    expect(result.content).toContain("](/blog/de/proxmox-czesc-druga)")
+
+    const frontmatterFixes = result.fixes.filter((fix) =>
+      fix.startsWith("frontmatter")
+    )
+    expect(frontmatterFixes).toHaveLength(3)
+  })
+
+  it("removes an empty coverImage line", () => {
+    const content = [
+      "---",
+      "title: T",
+      "description: desc",
+      "date: 2026-07-08T12:00:00.000Z",
+      "tags: nextjs, proxmox",
+      "coverImage:",
+      "---",
+      "",
+      "Body [self](/blog/de/proxmox-czesc-druga).",
+      "",
+    ].join("\n")
+
+    const result = fixPostIntegrity("proxmox-czesc-druga", content, {
+      knownSlugs: ["proxmox-czesc-druga"],
+      canonicalTags: ["nextjs", "proxmox"],
+      // An empty coverImage is stripped unconditionally, even if the predicate
+      // would happily accept any asset.
+      coverImageAssetExists: () => true,
+    })
+
+    expect(result.changed).toBe(true)
+    expect(result.content).not.toContain("coverImage")
+    expect(result.fixes).toContain(
+      "frontmatter: removed empty coverImage line"
+    )
+  })
+
+  it("leaves a coverImage that points at a real asset untouched", () => {
+    const content = [
+      "---",
+      "title: T",
+      "description: desc",
+      "date: 2026-07-08T12:00:00.000Z",
+      "tags: nextjs, proxmox",
+      "coverImage: /assets/images/real.png",
+      "---",
+      "",
+      "Body [self](/blog/de/proxmox-czesc-druga).",
+      "",
+    ].join("\n")
+
+    const result = fixPostIntegrity("proxmox-czesc-druga", content, {
+      knownSlugs: ["proxmox-czesc-druga"],
+      canonicalTags: ["nextjs", "proxmox"],
+      coverImageAssetExists: (assetPath) =>
+        assetPath === "/assets/images/real.png",
+    })
+
+    expect(result.changed).toBe(false)
+    expect(result.content).toBe(content)
+    expect(result.content).toContain("coverImage: /assets/images/real.png")
+  })
+
+  it("removes a coverImage that points at a missing asset", () => {
+    const content = [
+      "---",
+      "title: T",
+      "description: desc",
+      "date: 2026-07-08T12:00:00.000Z",
+      "tags: nextjs, proxmox",
+      "coverImage: /assets/images/ghost.png",
+      "---",
+      "",
+      "Body [self](/blog/de/proxmox-czesc-druga).",
+      "",
+    ].join("\n")
+
+    const result = fixPostIntegrity("proxmox-czesc-druga", content, {
+      knownSlugs: ["proxmox-czesc-druga"],
+      canonicalTags: ["nextjs", "proxmox"],
+      // Only the real asset exists, so the ghost cover is dropped.
+      coverImageAssetExists: (assetPath) =>
+        assetPath === "/assets/images/real.png",
+    })
+
+    expect(result.changed).toBe(true)
+    expect(result.content).not.toContain("coverImage")
+    expect(result.fixes).toContain(
+      "frontmatter: removed coverImage line pointing at missing asset /assets/images/ghost.png"
+    )
+  })
+
+  it("is a no-op on a file with no continuation or coverImage defect", () => {
+    const content = [
+      "---",
+      "title: Fine",
+      "description: Fine description",
+      "date: 2026-07-08T12:00:00.000Z",
+      "tags: nextjs, proxmox",
+      "coverImage: /assets/images/real.png",
+      "---",
+      "",
+      "Body [self](/blog/de/proxmox-czesc-druga).",
+      "",
+    ].join("\n")
+
+    const result = fixPostIntegrity("proxmox-czesc-druga", content, {
+      knownSlugs: ["proxmox-czesc-druga"],
+      canonicalTags: ["nextjs", "proxmox"],
+      coverImageAssetExists: () => true,
+    })
+
+    expect(result.changed).toBe(false)
+    expect(result.fixes).toEqual([])
+    expect(result.content).toBe(content)
+  })
 })

--- a/src/lib/post-integrity.ts
+++ b/src/lib/post-integrity.ts
@@ -29,6 +29,20 @@ const CANONICAL_FRONTMATTER_KEYS: Record<string, string> = {
 // the colon. The value after the colon is never captured, so it is preserved.
 const FRONTMATTER_KEY_LINE_REGEX = /^(\s*)([A-Za-z]+)(\s*:)/
 
+// A scalar tags line that actually carries a value (colon followed by a non
+// space), as opposed to a "tags:" block header whose real list items live on the
+// lines below. Only a scalar tags line can have stray continuations under it.
+const SCALAR_TAGS_LINE_REGEX = /^\s*tags\s*:\s*\S/
+
+// A dangling YAML list continuation: leading indent, a hyphen, a space, content.
+// After tags is canonicalized to a single scalar line, any of these immediately
+// below it is leftover from a prior malformed tags block and must go.
+const STRAY_LIST_LINE_REGEX = /^\s*-\s+\S/
+
+// A coverImage frontmatter line: indent, the key, the colon, then the raw value
+// captured to end of line so it can be tested for emptiness and asset existence.
+const COVER_IMAGE_LINE_REGEX = /^(\s*)coverImage(\s*):\s*(.*)$/
+
 export type PostIntegrityFixResult = {
   changed: boolean
   fixes: string[]
@@ -38,6 +52,11 @@ export type PostIntegrityFixResult = {
 export type PostIntegrityOptions = {
   knownSlugs?: string[]
   canonicalTags?: string[]
+  // Decides whether a coverImage value points at a real asset. Supplied by the
+  // CLI caller so this library never touches the filesystem. When omitted, a non
+  // empty coverImage is left alone (a missing file cannot be proven); an empty
+  // coverImage is always stripped regardless.
+  coverImageAssetExists?: (assetPath: string) => boolean
 }
 
 type HelperResult = {
@@ -54,10 +73,17 @@ type HelperResult = {
  * Also normalizes the casing of known frontmatter keys (TITLE: back to title:)
  * so a translation with uppercased keys cannot crash the build (DoD-8, F6).
  *
- * Pure: never touches the filesystem. The CLI caller supplies knownSlugs and
- * canonicalTags and owns all file I/O. Returns changed false for the already
- * correct case (content is returned unchanged); throws only for malformed input
- * with no frontmatter, mirroring parseFrontmatter.
+ * Finally strips frontmatter debris a prior malformed tags block or a bogus cover
+ * leaves behind (failure mode F7): dangling YAML list continuation lines under the
+ * canonical tags line, and an empty or dangling coverImage. Removing a broken
+ * coverImage lets the dynamic per topic OG take over (DoD-6). coverImage existence
+ * is decided by the optional coverImageAssetExists predicate, so the library stays
+ * filesystem free; the CLI caller supplies it.
+ *
+ * Pure: never touches the filesystem. The CLI caller supplies knownSlugs,
+ * canonicalTags, and coverImageAssetExists and owns all file I/O. Returns changed
+ * false for the already correct case (content is returned unchanged); throws only
+ * for malformed input with no frontmatter, mirroring parseFrontmatter.
  */
 export function fixPostIntegrity(
   canonicalSlug: string,
@@ -80,13 +106,24 @@ export function fixPostIntegrity(
   // canonicalized first and reinsertCanonicalTags sees the corrected frontmatter.
   const caseResult = normalizeFrontmatterKeyCasing(slugResult.content)
   const tagResult = reinsertCanonicalTags(caseResult.content, canonicalTags)
+  // Run last, once tags has been rewritten to a single canonical scalar line, so
+  // any list items below it are unambiguously stray leftovers.
+  const strayResult = stripStrayFrontmatterContinuations(
+    tagResult.content,
+    options?.coverImageAssetExists
+  )
 
-  const fixes = [...slugResult.fixes, ...caseResult.fixes, ...tagResult.fixes]
+  const fixes = [
+    ...slugResult.fixes,
+    ...caseResult.fixes,
+    ...tagResult.fixes,
+    ...strayResult.fixes,
+  ]
 
   return {
     changed: fixes.length > 0,
     fixes,
-    content: tagResult.content,
+    content: strayResult.content,
   }
 }
 
@@ -225,4 +262,84 @@ function tagsAreEqual(a: string[], b: string[]): boolean {
     return false
   }
   return a.every((tag, index) => tag === b[index])
+}
+
+/**
+ * Strip two kinds of frontmatter debris that a prior malformed tags block or a
+ * hallucinated cover leaves behind (failure mode F7), both self corrected by hand
+ * in production before this existed:
+ *
+ *   1. Dangling YAML list continuation lines ("- claude-code", "- blog") left
+ *      immediately under the tags line after it has been canonicalized to a single
+ *      scalar. Only stripped when the tags line carries a scalar value, so a real
+ *      "tags:" block header whose items live on the lines below is never eaten.
+ *   2. A coverImage line whose value is empty, or which points at a file that does
+ *      not exist. Removing it lets the dynamic per topic OG take over (DoD-6)
+ *      instead of shipping a broken cover. Existence is decided by the caller
+ *      supplied predicate, so this helper stays filesystem free; with no predicate
+ *      only the empty case is removed, since a missing file cannot be proven.
+ *
+ * Operates only on the leading frontmatter block, never the body. No-op (content
+ * returned byte identical) when neither defect is present.
+ */
+function stripStrayFrontmatterContinuations(
+  content: string,
+  coverImageAssetExists?: (assetPath: string) => boolean
+): HelperResult {
+  const fixes: string[] = []
+
+  const block = FRONTMATTER_BLOCK_REGEX.exec(content)
+  if (!block) {
+    return { content, fixes }
+  }
+
+  const [, open, inner, close] = block
+  const lines = inner.split("\n")
+  const removed = new Set<number>()
+
+  // 1. Dangling list continuations directly under a scalar tags line.
+  const tagsIndex = lines.findIndex((line) => SCALAR_TAGS_LINE_REGEX.test(line))
+  if (tagsIndex >= 0) {
+    for (let i = tagsIndex + 1; i < lines.length; i += 1) {
+      if (!STRAY_LIST_LINE_REGEX.test(lines[i])) {
+        break
+      }
+      removed.add(i)
+      fixes.push(
+        `frontmatter: removed stray tags continuation line "${lines[i].trim()}"`
+      )
+    }
+  }
+
+  // 2. Empty or dangling coverImage.
+  const coverIndex = lines.findIndex((line) =>
+    COVER_IMAGE_LINE_REGEX.test(line)
+  )
+  if (coverIndex >= 0 && !removed.has(coverIndex)) {
+    const match = COVER_IMAGE_LINE_REGEX.exec(lines[coverIndex])
+    const rawValue = match ? match[3] : ""
+    const value = rawValue
+      .trim()
+      .replace(/^["'](.*)["']$/, "$1")
+      .trim()
+    if (value === "") {
+      removed.add(coverIndex)
+      fixes.push("frontmatter: removed empty coverImage line")
+    } else if (coverImageAssetExists && !coverImageAssetExists(value)) {
+      removed.add(coverIndex)
+      fixes.push(
+        `frontmatter: removed coverImage line pointing at missing asset ${value}`
+      )
+    }
+  }
+
+  if (removed.size === 0) {
+    return { content, fixes }
+  }
+
+  const keptLines = lines.filter((_, index) => !removed.has(index))
+  const rebuilt =
+    open + keptLines.join("\n") + close + content.slice(block[0].length)
+
+  return { content: rebuilt, fixes }
 }


### PR DESCRIPTION
Three tech-debt fixes from the milestone audit, each closed by a deterministic guard with test evidence. Zero em dashes anywhere: this body was itself run through the new guard before the PR opened.

## FIX 1 (F7): post-integrity strips stray tags continuations and dangling coverImage

The deterministic fixer canonicalized the `tags:` line but left two defects behind, both self corrected by hand in production before this existed (the PRs that produced `i-made-my-blog-nag-me-on-slack` and `five-claude-code-skills-blog-pipeline`):

- a leftover YAML list (`- claude-code` / `- blog`) dangling under the canonical scalar tags line, and
- a hallucinated `coverImage` pointing at an empty value or a nonexistent asset.

New pure helper `stripStrayFrontmatterContinuations` in `src/lib/post-integrity.ts` removes any `- ` list line directly under a scalar tags line, and removes a `coverImage` whose value is empty or whose asset does not exist. It runs last in `fixPostIntegrity`, after tags is canonicalized so any list below it is unambiguously stray. A new `coverImageAssetExists` option keeps the library filesystem free; `scripts/fix-integrity.ts` supplies a `public/` rooted predicate so production actually benefits. Documented as F7 in `_shared/failure-modes.md`.

**Test evidence:** 5 new cases in `post-integrity.test.ts` (stray continuations cleaned to the canonical line, empty coverImage removed, real coverImage left alone, missing coverImage removed, no-defect no-op). `post-integrity.test.ts` now 11/11.

## FIX 2 (FUTURE-04): deterministic em dash guard for generated PR bodies

`verify-post`'s DoD-1 em dash scan only reads the four content `.mdx` files, so a generated PR body could still ship em dashes. Confirmed live: PR #9's own body carried exactly 13 U+2014 while its content files were clean.

New `src/lib/em-dash.ts` (`stripEmDashes`) plus `scripts/strip-em-dashes.ts` CLI (`bun run fix:em-dash --file <body>`) replace every U+2014 with a comma, guaranteeing the text cannot carry an em dash. `open-post-pr` now runs this over the body before opening the PR, backed by a hard rule. `verify-post` gained a one line scope note. The guard sources reference the character only through its Unicode escape, never the literal glyph, so they stay clean under their own scan.

**Test evidence:** 4 new cases in `em-dash.test.ts`. End to end: a body seeded with 3 em dashes, run through `bun run fix:em-dash`, came out with 0 U+2014 and its line structure intact.

## FIX 3: open-post-pr documents the built-in GitHub tool as primary

The skill documented `gh pr create` as its PR-creation path, but the last two live fires opened the PR through the harness's built-in GitHub integration, not the CLI. The procedure now names the built-in GitHub tool as the primary path, with `gh pr create` kept as an explicit fallback for environments that lack it.

## Verification

- `bun run test`: 24 passed (was 15; added 5 + 4). Full suite, not just the new files.
- `bunx tsc --noEmit`: rc 0.
- `bun run build`: succeeded, full route table, no errors.
- No literal U+2014 in any changed file.

Branch off `dev`. Never pushed to `dev` or `prod`; merge stays a human action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
